### PR TITLE
test: add "test" Makefile target and GitHub actions config to run it

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,40 @@
+# This workflow will build a golang project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
+
+name: Go
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.19'
+
+    - name: Build
+      run: go build -v ./...
+
+    - name: Test
+      run: make test
+
+    - name: Upload Go coverage results - HTML
+      uses: actions/upload-artifact@v3
+      with:
+        name: go-coverage
+        path: coverage.html
+
+    - name: Upload Go coverage results - txt
+      uses: actions/upload-artifact@v3
+      with:
+        name: go-coverage
+        path: coverage.txt
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Coverage
+coverage.*
+
+# Binary
+host-metering

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+GO := go
+TESTDIR := $(CURDIR)/test
+
+.PHONY: test
+test:
+	@echo "Running the unit tests..."
+
+	PATH=$(TESTDIR)/bin:$(PATH) \
+	$(GO) test -v \
+	-coverprofile=coverage.out \
+	-covermode=atomic \
+	-coverpkg=./... \
+	./...
+
+
+	@echo "Calculating the coverage..."
+	$(GO) tool cover -html=coverage.out -o coverage.html
+	$(GO) tool cover -func=coverage.out -o coverage.txt
+
+	@cat coverage.txt


### PR DESCRIPTION
 **test: add 'test' target to Makefile**
    
The difference with standard `go test` is that hostinfo tests require  to amend `$PATH` to execute `test/subscription-manager`.

**ci: add GitHub action for go build and test**
    
To run it on push to main and each PR to main.