### PR TITLE
build: tarball and rpm build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Build / Release
 dist/
 vendor/
+contrib/rpm/host-metering.spec
 
 # Coverage
 coverage.*

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Build / Release
+dist/
+vendor/
+
 # Coverage
 coverage.*
 

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,13 @@
 #!/usr/bin/make -f
 
 PROJECT := host-metering
+RPMNAME := host-metering
 VERSION := $(shell grep "Version" version/version.go | awk -F '"' '{print $$2}')
+SHORT_COMMIT ?= $(shell git rev-parse --short=8 HEAD)
+AUTORELEASE ?= "git$(shell date "+%Y%m%d%H%M")G$(SHORT_COMMIT)"
 
 DISTDIR ?= $(CURDIR)/dist
+RPMTOPDIR := $(DISTDIR)/rpmbuild
 
 GO := go
 TESTDIR := $(CURDIR)/test
@@ -58,6 +62,44 @@ tarball: distdir vendor
 
 	@echo "Compressing the tarball..."
 	gzip -f $(DISTDIR)/$(PROJECT)-$(VERSION).tar
+
+# RPM build
+.PHONY: rpm/spec
+rpm/spec:
+	sed "s/#VERSION#/${VERSION}/" contrib/rpm/host-metering.spec.in > contrib/rpm/$(RPMNAME).spec
+	sed "s/#AUTORELEASE#/${AUTORELEASE}/" -i contrib/rpm/$(RPMNAME).spec
+
+.PHONY: rpm/srpm
+rpm/srpm: tarball rpm/spec
+	mkdir -p $(RPMTOPDIR)/SOURCES
+	cp $(DISTDIR)/$(PROJECT)-$(VERSION).tar.gz $(RPMTOPDIR)/SOURCES/
+	rm -rf $(RPMTOPDIR)/SRPMS/*
+	rpmbuild --define '_topdir $(RPMTOPDIR)' -bs contrib/rpm/$(RPMNAME).spec
+
+.PHONY: rpm
+rpm: rpm/srpm
+	rpmbuild --define '_topdir $(RPMTOPDIR)' -bb contrib/rpm/$(RPMNAME).spec
+
+.PHONY: rpm/mock
+rpm/mock: rpm/srpm
+	mkdir -p $(DISTDIR)/mock7
+	mock -r epel-7-x86_64 \
+	     --resultdir=$(DISTDIR)/mock7/ \
+	     --rebuild $(RPMTOPDIR)/SRPMS/$(shell ls -1 $(RPMTOPDIR)/SRPMS)
+
+.PHONY: rpm/mock-8
+rpm/mock-8: rpm/srpm
+	mkdir -p $(DISTDIR)/mock8
+	mock -r centos-stream-8-x86_64 \
+	     --resultdir=$(DISTDIR)/mock8/ \
+	     --rebuild $(RPMTOPDIR)/SRPMS/$(shell ls -1 $(RPMTOPDIR)/SRPMS)
+
+.PHONY: rpm/mock-9
+rpm/mock-9: rpm/srpm
+	mkdir -p $(DISTDIR)/mock9
+	mock -r centos-stream-9-x86_64 \
+	     --resultdir=$(DISTDIR)/mock9 \
+	     --rebuild $(RPMTOPDIR)/SRPMS/$(shell ls -1 $(RPMTOPDIR)/SRPMS)
 
 # Clean
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -58,3 +58,14 @@ tarball: distdir vendor
 
 	@echo "Compressing the tarball..."
 	gzip -f $(DISTDIR)/$(PROJECT)-$(VERSION).tar
+
+# Clean
+.PHONY: clean
+clean:
+	@echo "Cleaning the project..."
+	rm -rf $(DISTDIR)
+	rm -rf $(CURDIR)/vendor
+	rm -rf $(CURDIR)/coverage.out
+	rm -rf $(CURDIR)/coverage.html
+	rm -rf $(CURDIR)/coverage.txt
+	rm -rf $(CURDIR)/$(PROJECT)

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,10 @@
+#!/usr/bin/make -f
+
+PROJECT := host-metering
+VERSION := $(shell grep "Version" version/version.go | awk -F '"' '{print $$2}')
+
+DISTDIR ?= $(CURDIR)/dist
+
 GO := go
 TESTDIR := $(CURDIR)/test
 
@@ -18,3 +25,36 @@ test:
 	$(GO) tool cover -func=coverage.out -o coverage.txt
 
 	@cat coverage.txt
+
+# Release
+.PHONY: version
+version:
+	@echo $(VERSION)
+
+.PHONY: distdir
+distdir:
+	@echo "Creating the destination directory..."
+	mkdir -p $(DISTDIR)
+
+.PHONY: vendor
+vendor:
+	@echo "Downloading go dependencies..."
+	$(GO) mod tidy && $(GO) mod vendor
+
+.PHONY: tarball
+tarball: distdir vendor
+	@echo "Creating a tarball with the source code..."
+	git archive \
+	    --format="tar" \
+	    --prefix=$(PROJECT)-$(VERSION)/ \
+	    --output $(DISTDIR)/$(PROJECT)-$(VERSION).tar \
+	    HEAD
+
+	@echo "Adding go dependencies to the tarball..."
+	tar --append \
+	    --transform="s/^\./$(PROJECT)-$(VERSION)/" \
+	    --file $(DISTDIR)/$(PROJECT)-$(VERSION).tar \
+	    ./vendor
+
+	@echo "Compressing the tarball..."
+	gzip -f $(DISTDIR)/$(PROJECT)-$(VERSION).tar

--- a/contrib/rpm/host-metering.spec.in
+++ b/contrib/rpm/host-metering.spec.in
@@ -1,0 +1,71 @@
+%bcond_without check
+
+%if 0%{?rhel} <= 7 && ! 0%{?fedora} && ! 0%{?centos}
+%define gobuild(o:) scl enable go-toolset-1.19 -- go build -mod vendor -buildmode pie -compiler gc -tags="rpm_crashtraceback ${BUILDTAGS:-}" -ldflags "${GO_LDFLAGS:-} ${LDFLAGS:-} -B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \\n') -extldflags '-Wl,-z,relro -Wl,-z,now -specs=/usr/lib/rpm/redhat/redhat-hardened-ld'" -a -v %{?**};
+%endif
+%if 0%{?rhel} <= 7 && ! 0%{?fedora} && 0%{?centos}
+
+%define gobuild(o:) go build -mod vendor -buildmode pie -compiler gc -tags="rpm_crashtraceback ${BUILDTAGS:-}" -ldflags "${GO_LDFLAGS:-} ${LDFLAGS:-} -B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \\n') -extldflags '-Wl,-z,relro -Wl,-z,now -specs=/usr/lib/rpm/redhat/redhat-hardened-ld'" -a -v %{?**};
+%endif
+
+%global goipath         github.com/RedHatInsights/host-metering
+%global forgeurl        https://github.com/RedHatInsights/host-metering/
+%global autorelease     #AUTORELEASE#
+%global gomodulesmode   GO111MODULE=on
+
+
+%global godocs          README.md
+
+Name:           host-metering
+Version:        #VERSION#
+Release:        %{autorelease}%{?dist}
+Summary:        None
+
+License:        Apache-2.0
+ExcludeArch:    %{ix86} s390 ppc ppc64
+URL:            %{gourl}
+
+Source:         %{name}-%{version}.tar.gz
+
+%if 0%{?rhel} <= 7 && ! 0%{?fedora} && ! 0%{?centos}
+BuildRequires: go-toolset-1.19
+%else
+BuildRequires: golang >= 1.19
+BuildRequires: systemd-rpm-macros
+%endif
+BuildRequires: git
+
+%description
+Host metering service
+
+%gopkg
+
+%prep
+%setup -q -b 0
+
+# for possible downstream patches
+%autopatch -p1
+
+%build
+pwd
+%gobuild -o $(pwd)/bin/host-metering %{goipath}
+
+%install
+install -m 0755 -vd                     %{buildroot}%{_bindir}
+install -m 0755 -vp $(pwd)/bin/*        %{buildroot}%{_bindir}/
+install -m 0755 -vd                     %{buildroot}%{_unitdir}
+install -m 644 contrib/systemd/host-metering.service %{buildroot}%{_unitdir}/%{name}.service
+
+%if %{with check}
+%check
+%endif
+
+%files
+%doc README.md
+%{_bindir}/*
+%attr(644,root,root) %{_unitdir}/%{name}.service
+
+
+%changelog
+* Mon Oct 2 2023 Vobornik Petr <pvoborni@redhat.com> - #VERSION#-#AUTORELEASE#
+- No changelog. The history is kept in Git, downstreams have own logs.

--- a/contrib/systemd/host-metering.service
+++ b/contrib/systemd/host-metering.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Host metering service
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=simple
+Environment=LC_ALL=C.UTF-8
+ExecStart=/usr/bin/host-metering daemon
+ExecReload=/usr/bin/kill -HUP $MAINPID
+
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/go.mod
+++ b/go.mod
@@ -3,18 +3,14 @@ module github.com/RedHatInsights/host-metering
 go 1.19
 
 require (
+	git.sr.ht/~spc/go-log v0.0.0-20230531172318-1397be06f5f4 // direct
 	github.com/fsnotify/fsnotify v1.6.0 // direct
 	github.com/gogo/protobuf v1.3.2 // direct
 	github.com/golang/snappy v0.0.4 // direct
-	github.com/prometheus/prometheus v0.45.0 // direct
 	github.com/prometheus/procfs v0.11.0 // direct
-)
-
-require (
+	github.com/prometheus/prometheus v0.45.0 // direct
 	github.com/tidwall/wal v1.1.7 // direct
 )
-
-require git.sr.ht/~spc/go-log v0.0.0-20230531172318-1397be06f5f4
 
 require (
 	github.com/tidwall/gjson v1.16.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,12 @@
-github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
-github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 git.sr.ht/~spc/go-log v0.0.0-20230531172318-1397be06f5f4 h1:Z49DWDPi2qdWYkpgq+WEv1hQIGB2fVmva361Zs7/Qzg=
 git.sr.ht/~spc/go-log v0.0.0-20230531172318-1397be06f5f4/go.mod h1:IKiYUc0lWbZO4uSV0kWNzJSFnABNdrybpPWo46CGgFM=
+github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
+github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/prometheus/procfs v0.11.0 h1:5EAgkfkMl659uZPbe9AS2N68a7Cc1TJbPEuGzFuRbyk=

--- a/notify/prometheus.go
+++ b/notify/prometheus.go
@@ -11,6 +11,7 @@ import (
 	"github.com/RedHatInsights/host-metering/config"
 	"github.com/RedHatInsights/host-metering/hostinfo"
 	"github.com/RedHatInsights/host-metering/logger"
+	"github.com/RedHatInsights/host-metering/version"
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
 	"github.com/prometheus/prometheus/prompb"
@@ -127,7 +128,7 @@ func newPrometheusRequest(hostinfo *hostinfo.HostInfo, cfg *config.Config, sampl
 	req.Header.Add("Content-Encoding", "snappy")
 	req.Header.Set("Content-Type", "application/x-protobuf")
 	req.Header.Set("X-Prometheus-Remote-Write-Version", "0.1.0")
-	req.Header.Set("User-Agent", "host-metering/0.1.0")
+	req.Header.Set("User-Agent", "host-metering/"+version.Version)
 
 	return req, nil
 }

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,3 @@
+package version
+
+const Version = "0.1.0"


### PR DESCRIPTION
Adds a way to build rpms. This should be then usable by downstreams and in COPR.

Commits:

**refactor: introduce Version constant**

To have this value on a single place and then to use it in a release
process.

**build: create release tarball**

Add `tarball` Makefile target which creates a tarball with the source
code and go dependencies. The name of tarball contains the current
version.

**build: tidy go modules**

Cleanup order and the way go modules are listed.

**build: add Makefile clean target**

To remove build/test artifacts.

**feat: add systemd service unit file**

To run as a deamon.

**build: rpm**

Add rpm spec and Makefile targets to install and run host-metering from
RPM.

The Makefile targets allow to build it directly on current host (rpm) or
via mock in several build targets.