### PR TITLE
build: add COPR support

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,0 +1,12 @@
+#!/usr/bin/make -f
+
+srpm:
+	# Setup development environment
+	dnf install -y git make curl gzip tar rpm-build golang
+
+	# Generate SRPM
+	make rpm/srpm
+
+	if [[ "${outdir}" != "" ]]; then \
+		mv dist/rpmbuild/SRPMS/* ${outdir}/; \
+	fi


### PR DESCRIPTION
Add Makefile which prepares srpm for COPR. This can be then used by
e.g. https://copr.fedorainfracloud.org/


Tested here: https://copr.fedorainfracloud.org/coprs/pvoborni/host-metering/build/6486422/ 

When this is merged, I'll change the ^^ repo to  `main` branch of this project and add a webhook to trigger a  rebuild on each merge. 

Rebased on top of: https://github.com/RedHatInsights/host-metering/pull/2 