### PR TITLE
feat: configurable Prometheus remote write timeout

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -20,6 +20,7 @@ const (
 	DefaultWriteRetryAttempts   = 8
 	DefaultWriteRetryMinInt     = 1 * time.Second
 	DefaultWriteRetryMaxInt     = 10 * time.Second
+	DefaultWriteTimeout         = 60 * time.Second
 	DefaultMetricsMaxAge        = 5400 * time.Second
 	DefaultMetricsWALPath       = "/var/run/host-metering/metrics"
 	DefaultLogLevel             = "INFO"
@@ -36,6 +37,7 @@ type Config struct {
 	WriteRetryAttempts   uint
 	WriteRetryMinInt     time.Duration
 	WriteRetryMaxInt     time.Duration
+	WriteTimeout         time.Duration
 	MetricsMaxAge        time.Duration
 	MetricsWALPath       string
 	LogLevel             string // one of "ERROR", "WARN", "INFO", "DEBUG", "TRACE"
@@ -53,6 +55,7 @@ func NewConfig() *Config {
 		WriteRetryAttempts:   DefaultWriteRetryAttempts,
 		WriteRetryMinInt:     DefaultWriteRetryMinInt,
 		WriteRetryMaxInt:     DefaultWriteRetryMaxInt,
+		WriteTimeout:         DefaultWriteTimeout,
 		MetricsMaxAge:        DefaultMetricsMaxAge,
 		MetricsWALPath:       DefaultMetricsWALPath,
 		LogLevel:             DefaultLogLevel,
@@ -73,6 +76,7 @@ func (c *Config) String() string {
 			fmt.Sprintf("  WriteRetryAttempts: %d", c.WriteRetryAttempts),
 			fmt.Sprintf("  WriteRetryMinIntSec: %.0f", c.WriteRetryMinInt.Seconds()),
 			fmt.Sprintf("  WriteRetryMaxIntSec: %.0f", c.WriteRetryMaxInt.Seconds()),
+			fmt.Sprintf("  WriteTimeoutSec: %.0f", c.WriteTimeout.Seconds()),
 			fmt.Sprintf("  MetricsMaxAgeSec: %.0f", c.MetricsMaxAge.Seconds()),
 			fmt.Sprintf("  MetricsWALPath: %s", c.MetricsWALPath),
 			fmt.Sprintf("  LogLevel: %s", c.LogLevel),
@@ -115,6 +119,10 @@ func (c *Config) UpdateFromEnvVars() error {
 	}
 	if v := os.Getenv("HOST_METERING_WRITE_RETRY_MAX_INT_SEC"); v != "" {
 		c.WriteRetryMaxInt, err = parseSeconds("HOST_METERING_WRITE_RETRY_MAX_INT_SEC", v, c.WriteRetryMaxInt)
+		multiError.Add(err)
+	}
+	if v := os.Getenv("HOST_METERING_WRITE_TIMEOUT_SEC"); v != "" {
+		c.WriteTimeout, err = parseSeconds("HOST_METERING_WRITE_TIMEOUT_SEC", v, c.WriteTimeout)
 		multiError.Add(err)
 	}
 	if v := os.Getenv("HOST_METERING_METRICS_MAX_AGE_SEC"); v != "" {
@@ -225,6 +233,10 @@ func (c *Config) UpdateFromConfigFile(path string) error {
 	}
 	if v, ok := config[section]["write_retry_max_int_sec"]; ok {
 		c.WriteRetryMaxInt, err = parseSeconds("write_retry_max_int_sec", v, c.WriteRetryMaxInt)
+		multiError.Add(err)
+	}
+	if v, ok := config[section]["write_timeout_sec"]; ok {
+		c.WriteTimeout, err = parseSeconds("write_timeout_sec", v, c.WriteTimeout)
 		multiError.Add(err)
 	}
 	if v, ok := config[section]["metrics_max_age_sec"]; ok {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -21,6 +21,7 @@ func TestDefaultConfig(t *testing.T) {
 		"  WriteRetryAttempts: 8\n" +
 		"  WriteRetryMinIntSec: 1\n" +
 		"  WriteRetryMaxIntSec: 10\n" +
+		"  WriteTimeoutSec: 60\n" +
 		"  MetricsMaxAgeSec: 5400\n" +
 		"  MetricsWALPath: /var/run/host-metering/metrics\n" +
 		"  LogLevel: INFO\n" +
@@ -66,6 +67,7 @@ func TestConfigFile(t *testing.T) {
 		"  WriteRetryAttempts: 4\n" +
 		"  WriteRetryMinIntSec: 5\n" +
 		"  WriteRetryMaxIntSec: 6\n" +
+		"  WriteTimeoutSec: 6\n" +
 		"  MetricsMaxAgeSec: 700\n" +
 		"  MetricsWALPath: /tmp/metrics\n" +
 		"  LogLevel: ERROR\n" +
@@ -84,6 +86,7 @@ func TestConfigFile(t *testing.T) {
 		"write_retry_attempts = 4\n" +
 		"write_retry_min_int_sec = 5\n" +
 		"write_retry_max_int_sec = 6\n" +
+		"write_timeout_sec = 6\n" +
 		"metrics_max_age_sec = 700\n" +
 		"metrics_wal_path = /tmp/metrics\n" +
 		"log_level = ERROR\n" +
@@ -105,7 +108,8 @@ func TestConfigFile(t *testing.T) {
 		"write_retry_attempts = d\n" +
 		"write_retry_min_int_sec = e\n" +
 		"write_retry_max_int_sec = f\n" +
-		"metrics_max_age_sec = g\n"
+		"write_timeout_sec = g\n" +
+		"metrics_max_age_sec = h\n"
 
 	createConfigFile(t, path, fileContent)
 	err = c.UpdateFromConfigFile(path)
@@ -117,7 +121,8 @@ func TestConfigFile(t *testing.T) {
 		"invalid value of 'write_retry_attempts': strconv.ParseUint: parsing \"d\": invalid syntax\n" +
 		"invalid value of 'write_retry_min_int_sec': strconv.ParseUint: parsing \"e\": invalid syntax\n" +
 		"invalid value of 'write_retry_max_int_sec': strconv.ParseUint: parsing \"f\": invalid syntax\n" +
-		"invalid value of 'metrics_max_age_sec': strconv.ParseUint: parsing \"g\": invalid syntax\n"
+		"invalid value of 'write_timeout_sec': strconv.ParseUint: parsing \"g\": invalid syntax\n" +
+		"invalid value of 'metrics_max_age_sec': strconv.ParseUint: parsing \"h\": invalid syntax\n"
 
 	checkString(t, err.Error(), expectedMsg)
 	checkString(t, c.String(), expectedCfg)
@@ -139,6 +144,7 @@ func TestEnvVariables(t *testing.T) {
 		"  WriteRetryAttempts: 4\n" +
 		"  WriteRetryMinIntSec: 5\n" +
 		"  WriteRetryMaxIntSec: 6\n" +
+		"  WriteTimeoutSec: 6\n" +
 		"  MetricsMaxAgeSec: 700\n" +
 		"  MetricsWALPath: /tmp/metrics\n" +
 		"  LogLevel: ERROR\n" +
@@ -154,6 +160,7 @@ func TestEnvVariables(t *testing.T) {
 	t.Setenv("HOST_METERING_WRITE_RETRY_ATTEMPTS", "4")
 	t.Setenv("HOST_METERING_WRITE_RETRY_MIN_INT_SEC", "5")
 	t.Setenv("HOST_METERING_WRITE_RETRY_MAX_INT_SEC", "6")
+	t.Setenv("HOST_METERING_WRITE_TIMEOUT_SEC", "6")
 	t.Setenv("HOST_METERING_METRICS_MAX_AGE_SEC", "700")
 	t.Setenv("HOST_METERING_METRICS_WAL_PATH", "/tmp/metrics")
 	t.Setenv("HOST_METERING_LOG_LEVEL", "ERROR")
@@ -173,7 +180,8 @@ func TestEnvVariables(t *testing.T) {
 	t.Setenv("HOST_METERING_WRITE_RETRY_ATTEMPTS", "d")
 	t.Setenv("HOST_METERING_WRITE_RETRY_MIN_INT_SEC", "e")
 	t.Setenv("HOST_METERING_WRITE_RETRY_MAX_INT_SEC", "f")
-	t.Setenv("HOST_METERING_METRICS_MAX_AGE_SEC", "g")
+	t.Setenv("HOST_METERING_WRITE_TIMEOUT_SEC", "g")
+	t.Setenv("HOST_METERING_METRICS_MAX_AGE_SEC", "h")
 
 	// Environment variables are invalid. Keep the previous configuration.
 	err = c.UpdateFromEnvVars()
@@ -185,7 +193,8 @@ func TestEnvVariables(t *testing.T) {
 		"invalid value of 'HOST_METERING_WRITE_RETRY_ATTEMPTS': strconv.ParseUint: parsing \"d\": invalid syntax\n" +
 		"invalid value of 'HOST_METERING_WRITE_RETRY_MIN_INT_SEC': strconv.ParseUint: parsing \"e\": invalid syntax\n" +
 		"invalid value of 'HOST_METERING_WRITE_RETRY_MAX_INT_SEC': strconv.ParseUint: parsing \"f\": invalid syntax\n" +
-		"invalid value of 'HOST_METERING_METRICS_MAX_AGE_SEC': strconv.ParseUint: parsing \"g\": invalid syntax\n"
+		"invalid value of 'HOST_METERING_WRITE_TIMEOUT_SEC': strconv.ParseUint: parsing \"g\": invalid syntax\n" +
+		"invalid value of 'HOST_METERING_METRICS_MAX_AGE_SEC': strconv.ParseUint: parsing \"h\": invalid syntax\n"
 
 	checkString(t, c.String(), expectedCfg)
 	checkString(t, err.Error(), expectedMsg)
@@ -204,6 +213,7 @@ func clearEnvironment() {
 	_ = os.Unsetenv("HOST_METERING_WRITE_RETRY_ATTEMPTS")
 	_ = os.Unsetenv("HOST_METERING_WRITE_RETRY_MIN_INT_SEC")
 	_ = os.Unsetenv("HOST_METERING_WRITE_RETRY_MAX_INT_SEC")
+	_ = os.Unsetenv("HOST_METERING_WRITE_TIMEOUT_SEC")
 	_ = os.Unsetenv("HOST_METERING_METRICS_MAX_AGE_SEC")
 	_ = os.Unsetenv("HOST_METERING_METRICS_WAL_PATH")
 	_ = os.Unsetenv("HOST_METERING_LOG_LEVEL")

--- a/notify/prometheus.go
+++ b/notify/prometheus.go
@@ -18,8 +18,6 @@ import (
 
 // See https://prometheus.io/docs/concepts/remote_write_spec/ for specifiction of Prometheus remote write
 
-const requestTimeout time.Duration = 60 * time.Second
-
 // Should be used only for testing
 var tlsInsecureSkipVerify = false
 
@@ -55,17 +53,17 @@ func (n *PrometheusNotifier) createHttpClient() error {
 		return err
 	}
 
-	n.client, err = newMTLSHttpClient(keypair)
+	n.client, err = newMTLSHttpClient(keypair, n.cfg.WriteTimeout)
 	return err
 }
 
-func newMTLSHttpClient(keypair tls.Certificate) (*http.Client, error) {
+func newMTLSHttpClient(keypair tls.Certificate, timeout time.Duration) (*http.Client, error) {
 	tlsConfig := &tls.Config{
 		Certificates:       []tls.Certificate{keypair},
 		InsecureSkipVerify: tlsInsecureSkipVerify,
 	}
 	return &http.Client{
-		Timeout: requestTimeout,
+		Timeout: timeout,
 		Transport: &http.Transport{
 			TLSClientConfig: tlsConfig,
 		},


### PR DESCRIPTION
Makes it possible to change timeout of http client which does Prometheus remote write via:

- `write_timeout_sec` in config file
- `HOST_METERING_WRITE_TIMEOUT_SEC` env var