### PR TITLE
feat(notify): recreate http client on host info change

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -161,6 +161,7 @@ func (d *Daemon) loadHostInfo() error {
 	logger.Infoln("HostInfo loaded")
 	logger.Infoln(hostInfo.String())
 	d.hostInfo = hostInfo
+	d.notifier.HostChanged()
 	return nil
 }
 

--- a/notify/notifier.go
+++ b/notify/notifier.go
@@ -9,6 +9,9 @@ import (
 
 type Notifier interface {
 	Notify(samples []prompb.Sample, hostinfo *hostinfo.HostInfo) error
+
+	// HostChanged tells notifier that related information on host has changed
+	HostChanged()
 }
 
 func FilterSamplesByAge(samples []prompb.Sample, maxAge time.Duration) []prompb.Sample {

--- a/notify/prometheus.go
+++ b/notify/prometheus.go
@@ -24,9 +24,9 @@ const requestTimeout time.Duration = 60 * time.Second
 var tlsInsecureSkipVerify = false
 
 type PrometheusNotifier struct {
-	cfg    *config.Config
-	lastId string
-	client *http.Client
+	cfg         *config.Config
+	validClient bool
+	client      *http.Client
 }
 
 func NewPrometheusNotifier(cfg *config.Config) *PrometheusNotifier {
@@ -36,17 +36,21 @@ func NewPrometheusNotifier(cfg *config.Config) *PrometheusNotifier {
 }
 
 func (n *PrometheusNotifier) Notify(samples []prompb.Sample, hostinfo *hostinfo.HostInfo) error {
-	if n.lastId != hostinfo.HostId {
+	if !n.validClient || n.client == nil {
 		if err := n.createHttpClient(); err != nil {
 			return err
 		}
-		n.lastId = hostinfo.HostId
+		n.validClient = true
 	}
 	request, err := newPrometheusRequest(hostinfo, n.cfg, samples)
 	if err != nil {
 		return err
 	}
 	return prometheusRemoteWrite(n.client, n.cfg, request)
+}
+
+func (n *PrometheusNotifier) HostChanged() {
+	n.validClient = false
 }
 
 func (n *PrometheusNotifier) createHttpClient() error {

--- a/notify/prometheus_test.go
+++ b/notify/prometheus_test.go
@@ -80,8 +80,8 @@ func TestNotify(t *testing.T) {
 	}
 	checkCalled(t, called, 2)
 
-	// Test that http client is recreated when hostId changes
-	hostinfo.HostId = "test2"
+	// Test that http client is recreated when host info changes
+	n.HostChanged()
 	err = n.Notify(samples, hostinfo)
 	checkError(t, err, "Failed to notify")
 


### PR DESCRIPTION
Http client needs to be recreated when certificate changes. PrometheusNotifier created another detection mechanism by checking if host id changed. This fails e.g., in cases when certificate is renewed (id is the same).

This patch changes the behavior to more generic - to reload on any hostinfo change (host info has to be reloaded when certifcate changes) thus transitively also on the certificate change.