### PR TITLE
feat: SELinux policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 dist/
 vendor/
 contrib/rpm/host-metering.spec
+contrib/selinux/tmp/
+contrib/selinux/host-metering.pp
 
 # Coverage
 coverage.*

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,13 @@ test:
 
 	@cat coverage.txt
 
+# Build
+.PHONY: build-selinux
+build-selinux:
+	@echo "Building SELinux policy..."
+	cd contrib/selinux && \
+		make -f /usr/share/selinux/devel/Makefile $(PROJECT).pp || exit
+
 # Release
 .PHONY: version
 version:
@@ -111,3 +118,5 @@ clean:
 	rm -rf $(CURDIR)/coverage.html
 	rm -rf $(CURDIR)/coverage.txt
 	rm -rf $(CURDIR)/$(PROJECT)
+	rm -rf $(CURDIR)/contrib/selinux/tmp
+	rm -rf $(CURDIR)/contrib/selinux/*.pp

--- a/contrib/rpm/host-metering.spec.in
+++ b/contrib/rpm/host-metering.spec.in
@@ -12,9 +12,12 @@
 %global forgeurl        https://github.com/RedHatInsights/host-metering/
 %global autorelease     #AUTORELEASE#
 %global gomodulesmode   GO111MODULE=on
-
-
 %global godocs          README.md
+
+# macros needed by SELinux
+%global selinuxtype     targeted
+%global moduletype      contrib
+%global modulename      host-metering
 
 Name:           host-metering
 Version:        #VERSION#
@@ -34,11 +37,23 @@ BuildRequires: golang >= 1.19
 BuildRequires: systemd-rpm-macros
 %endif
 BuildRequires: git
+BuildRequires: policycoreutils
+BuildRequires: selinux-policy
+BuildRequires: selinux-policy-devel
+Requires:      %{name}-selinux = %{version}-%{release}
 
 %description
 Host metering service
 
 %gopkg
+
+%package selinux
+Summary:       SELinux policy module for host-metering
+BuildArch:     noarch
+%{?selinux_requires}
+
+%description selinux
+This package installs and sets up the SELinux policy security module for host-metering.
 
 %prep
 %setup -q -b 0
@@ -49,6 +64,10 @@ Host metering service
 %build
 pwd
 %gobuild -o $(pwd)/bin/host-metering %{goipath}
+make build-selinux
+
+%pre selinux
+%selinux_relabel_pre -s %{selinuxtype}
 
 %install
 install -m 0755 -vd                     %{buildroot}%{_bindir}
@@ -56,14 +75,37 @@ install -m 0755 -vp $(pwd)/bin/*        %{buildroot}%{_bindir}/
 install -m 0755 -vd                     %{buildroot}%{_unitdir}
 install -m 644 contrib/systemd/host-metering.service %{buildroot}%{_unitdir}/%{name}.service
 
+install -D -m 0644 contrib/selinux/%{modulename}.pp %{buildroot}%{_datadir}/selinux/packages/%{selinuxtype}/%{modulename}.pp
+install -D -p -m 644 contrib/selinux/%{modulename}.if %{buildroot}%{_datadir}/selinux/devel/include/distributed/%{modulename}.if
+
 %if %{with check}
 %check
 %endif
+
+%post selinux
+%selinux_modules_install -s %{selinuxtype} %{_datadir}/selinux/packages/%{selinuxtype}/%{modulename}.pp
+%selinux_relabel_post -s %{selinuxtype}
+
+if [ "$1" -le "1" ]; then # First install
+   # the daemon needs to be restarted for the custom label to be applied
+   %systemd_postun_with_restart %{modulename}.service
+fi
+
+%postun selinux
+if [ $1 -eq 0 ]; then
+    %selinux_modules_uninstall -s %{selinuxtype} %{modulename}
+    %selinux_relabel_post -s %{selinuxtype}
+fi
 
 %files
 %doc README.md
 %{_bindir}/*
 %attr(644,root,root) %{_unitdir}/%{name}.service
+
+%files selinux
+%{_datadir}/selinux/packages/%{selinuxtype}/%{modulename}.pp
+%{_datadir}/selinux/devel/include/distributed/%{modulename}.if
+%ghost %{_sharedstatedir}/selinux/%{selinuxtype}/active/modules/200/%{modulename}
 
 
 %changelog

--- a/contrib/selinux/host-metering-selinux.sh
+++ b/contrib/selinux/host-metering-selinux.sh
@@ -1,0 +1,55 @@
+#!/bin/sh -e
+
+DIRNAME=`dirname $0`
+cd $DIRNAME
+USAGE="$0 [ --update ]"
+if [ `id -u` != 0 ]; then
+echo 'You must be root to run this script'
+exit 1
+fi
+
+if [ $# -eq 1 ]; then
+	if [ "$1" = "--update" ] ; then
+		time=`ls -l --time-style="+%x %X" host-metering.te | awk '{ printf "%s %s", $6, $7 }'`
+		rules=`ausearch --start $time -m avc --raw -se host-metering`
+		if [ x"$rules" != "x" ] ; then
+			echo "Found avc's to update policy with"
+			echo -e "$rules" | audit2allow -R
+			echo "Do you want these changes added to policy [y/n]?"
+			read ANS
+			if [ "$ANS" = "y" -o "$ANS" = "Y" ] ; then
+				echo "Updating policy"
+				echo -e "$rules" | audit2allow -R >> host-metering.te
+				# Fall though and rebuild policy
+			else
+				exit 0
+			fi
+		else
+			echo "No new avcs found"
+			exit 0
+		fi
+	else
+		echo -e $USAGE
+		exit 1
+	fi
+elif [ $# -ge 2 ] ; then
+	echo -e $USAGE
+	exit 1
+fi
+
+echo "Building and Loading Policy"
+set -x
+make -f /usr/share/selinux/devel/Makefile host-metering.pp || exit
+/usr/sbin/semodule -i host-metering.pp
+
+# Generate a man page off the installed module
+sepolicy manpage -p . -d hostmetering_t
+# Fixing the file context on /usr/bin/host-metering
+/sbin/restorecon -F -R -v /usr/bin/host-metering
+# Fixing the file context on /usr/lib/systemd/system/host-metering.service
+/sbin/restorecon -F -R -v /usr/lib/systemd/system/host-metering.service
+# Fixing the file context on /var/run/host-metering
+/sbin/restorecon -F -R -v /var/run/host-metering
+# Generate a rpm package for the newly generated policy
+
+pwd=$(pwd)

--- a/contrib/selinux/host-metering.fc
+++ b/contrib/selinux/host-metering.fc
@@ -1,0 +1,5 @@
+/usr/bin/host-metering		--	gen_context(system_u:object_r:hostmetering_exec_t,s0)
+
+/usr/lib/systemd/system/host-metering.service		--	gen_context(system_u:object_r:hostmetering_unit_file_t,s0)
+
+/var/run/host-metering(/.*)?		gen_context(system_u:object_r:hostmetering_var_run_t,s0)

--- a/contrib/selinux/host-metering.if
+++ b/contrib/selinux/host-metering.if
@@ -1,0 +1,126 @@
+
+## <summary>policy for host-metering</summary>
+
+########################################
+## <summary>
+##	Execute hostmetering_exec_t in the host-metering domain.
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed to transition.
+## </summary>
+## </param>
+#
+interface(`hostmetering_domtrans',`
+	gen_require(`
+		type hostmetering_t, hostmetering_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	domtrans_pattern($1, hostmetering_exec_t, hostmetering_t)
+')
+
+######################################
+## <summary>
+##	Execute host-metering in the caller domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`hostmetering_exec',`
+	gen_require(`
+		type hostmetering_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	can_exec($1, hostmetering_exec_t)
+')
+########################################
+## <summary>
+##	Read host-metering PID files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`hostmetering_read_pid_files',`
+	gen_require(`
+		type hostmetering_var_run_t;
+	')
+
+	files_search_pids($1)
+	read_files_pattern($1, hostmetering_var_run_t, hostmetering_var_run_t)
+')
+
+########################################
+## <summary>
+##	Execute host-metering server in the host-metering domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+interface(`hostmetering_systemctl',`
+	gen_require(`
+		type hostmetering_t;
+		type hostmetering_unit_file_t;
+	')
+
+	systemd_exec_systemctl($1)
+        systemd_read_fifo_file_passwd_run($1)
+	allow $1 hostmetering_unit_file_t:file read_file_perms;
+	allow $1 hostmetering_unit_file_t:service manage_service_perms;
+
+	ps_process_pattern($1, hostmetering_t)
+')
+
+
+########################################
+## <summary>
+##	All of the rules required to administrate
+##	an host-metering environment
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`hostmetering_admin',`
+	gen_require(`
+		type hostmetering_t;
+		type hostmetering_var_run_t;
+	type hostmetering_unit_file_t;
+	')
+
+	allow $1 hostmetering_t:process { signal_perms };
+	ps_process_pattern($1, hostmetering_t)
+
+    tunable_policy(`deny_ptrace',`',`
+        allow $1 hostmetering_t:process ptrace;
+    ')
+
+	files_search_pids($1)
+	admin_pattern($1, hostmetering_var_run_t)
+
+	hostmetering_systemctl($1)
+	admin_pattern($1, hostmetering_unit_file_t)
+	allow $1 hostmetering_unit_file_t:service all_service_perms;
+	optional_policy(`
+		systemd_passwd_agent_exec($1)
+		systemd_read_fifo_file_passwd_run($1)
+	')
+')

--- a/contrib/selinux/host-metering.te
+++ b/contrib/selinux/host-metering.te
@@ -1,0 +1,88 @@
+policy_module(host-metering, 1.0.0)
+
+########################################
+#
+# Declarations
+#
+
+type hostmetering_t;
+type hostmetering_exec_t;
+init_daemon_domain(hostmetering_t, hostmetering_exec_t)
+
+type hostmetering_var_run_t;
+files_pid_file(hostmetering_var_run_t)
+
+type hostmetering_unit_file_t;
+systemd_unit_file(hostmetering_unit_file_t)
+
+type hostmetering_tmp_t;
+files_tmp_file(hostmetering_tmp_t)
+
+########################################
+#
+# host-metering local policy
+#
+allow hostmetering_t self:capability { setgid setuid sys_rawio };
+allow hostmetering_t self:fifo_file rw_fifo_file_perms;
+allow hostmetering_t self:unix_stream_socket create_stream_socket_perms;
+allow hostmetering_t self:unix_dgram_socket create_socket_perms;
+
+manage_dirs_pattern(hostmetering_t, hostmetering_var_run_t, hostmetering_var_run_t)
+manage_files_pattern(hostmetering_t, hostmetering_var_run_t, hostmetering_var_run_t)
+manage_lnk_files_pattern(hostmetering_t, hostmetering_var_run_t, hostmetering_var_run_t)
+files_pid_filetrans(hostmetering_t, hostmetering_var_run_t, { dir file lnk_file })
+
+manage_dirs_pattern(hostmetering_t, hostmetering_tmp_t, hostmetering_tmp_t)
+manage_files_pattern(hostmetering_t, hostmetering_tmp_t, hostmetering_tmp_t)
+files_tmp_filetrans(hostmetering_t, hostmetering_tmp_t, { dir file })
+
+kernel_getattr_proc(hostmetering_t)
+kernel_read_network_state(hostmetering_t)
+kernel_read_system_state(hostmetering_t)
+kernel_read_net_sysctls(hostmetering_t)
+
+auth_read_passwd(hostmetering_t)
+
+corecmd_exec_bin(hostmetering_t)
+corecmd_exec_shell(hostmetering_t)
+
+corenet_tcp_connect_http_port(hostmetering_t)
+corenet_tcp_connect_websm_port(hostmetering_t)
+
+dev_list_sysfs(hostmetering_t)
+dev_read_raw_memory(hostmetering_t)
+dev_read_sysfs(hostmetering_t)
+
+files_list_tmp(hostmetering_t)
+
+init_read_state(hostmetering_t)
+
+libs_exec_ldconfig(hostmetering_t)
+
+optional_policy(`
+     sysnet_dns_name_resolve(hostmetering_t)
+     sysnet_domtrans_ifconfig(hostmetering_t)
+     sysnet_exec_ifconfig(hostmetering_t)
+')
+
+optional_policy(`
+     dbus_system_bus_client(hostmetering_t)
+')
+
+optional_policy(`
+     dmidecode_domtrans(hostmetering_t)
+')
+
+optional_policy(`
+    rhnsd_manage_config(hostmetering_t)
+')
+
+optional_policy(`
+    gen_require(`
+        type rhsmcertd_config_t;
+    ')
+    manage_files_pattern(hostmetering_t, rhsmcertd_config_t, rhsmcertd_config_t)
+    rhsmcertd_manage_lib_files(hostmetering_t)
+    rhsmcertd_read_log(hostmetering_t)
+')
+


### PR DESCRIPTION
Commits:

**feat: selinux policy**

Adds SELinux policy for daemon running as a systemd service.

**build: selinux rpm package**

Adds build of host-metering-selinux package containing the SELinux
policy.
