### PR TITLE
fix: and tune HTTP Transport config

### DIFF
--- a/notify/prometheus.go
+++ b/notify/prometheus.go
@@ -70,8 +70,12 @@ func newMTLSHttpClient(keypair tls.Certificate, timeout time.Duration) (*http.Cl
 	return &http.Client{
 		Timeout: timeout,
 		Transport: &http.Transport{
-			Proxy:           http.ProxyFromEnvironment,
-			TLSClientConfig: tlsConfig,
+			Proxy:                 http.ProxyFromEnvironment,
+			TLSClientConfig:       tlsConfig,
+			MaxIdleConns:          2,
+			IdleConnTimeout:       90 * time.Second,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
 		},
 	}, nil
 }

--- a/notify/prometheus.go
+++ b/notify/prometheus.go
@@ -70,6 +70,7 @@ func newMTLSHttpClient(keypair tls.Certificate, timeout time.Duration) (*http.Cl
 	return &http.Client{
 		Timeout: timeout,
 		Transport: &http.Transport{
+			Proxy:           http.ProxyFromEnvironment,
 			TLSClientConfig: tlsConfig,
 		},
 	}, nil


### PR DESCRIPTION
**fix: follow proxy settings defined in env vars**

To follow HTTP_PROXY, HTTPS_PROXY, NO_PROXY env vars.

Custom initialiation of http client Transport caused that default proxy
which follows env vars was not used. Thus reintroducing it.

**fix: tune http Transport config**

Set's other defaults for transport which were otherwise lost by not
using the default transport.

`IdleConnTimeout`, `TLSHandshakeTimeout` and `ExpectContinueTimeout` are
the same as in `DefaultTransport`.

`MaxIdleConns` was set to 2 instead of default 100 just reduce it as we
expect one connection to a server at a time anyway and also
`DefaultMaxIdleConnsPerHost` is 2. I.e. it probably doesn't have
practical effect.

But it is probably useful to have keep-alive configuration for possible
re-tries when remote write returns 5xx.

DialContext and ForceAttemptHTTP2 were not set.