### PR TITLE
ci: add commit lint and semantic-release process

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "lts/*"
+      - name: Print versions
+        run: |
+          git --version
+          node --version
+          npm --version
+      - name: Install commitlint
+        run: |
+          npm install @commitlint/config-conventional@latest commitlint@latest
+      - name: Validate current commit (last commit) with commitlint
+        if: github.event_name == 'push'
+        run: npx commitlint --from HEAD~1 --to HEAD --verbose
+
+      - name: Validate PR commits with commitlint
+        if: github.event_name == 'pull_request'
+        run: npx commitlint --from ${{ github.event.pull_request.head.sha }}~${{ github.event.pull_request.commits }} --to ${{ github.event.pull_request.head.sha }} --verbose

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+# Release process that runs on on manual request (workflow_dispatch)
+
+# How it works:
+# 1. Prepares env to be able to run semantic-release
+# 2. Runs semantic-release which does the whole release process
+
+# See CONTRIBUTING.md for more information how the semantic-release works
+
+---
+name: Release
+on: workflow_dispatch
+
+permissions:
+  contents: read # for checkout
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # to be able to publish a GitHub release
+      issues: write # to be able to comment on released issues
+      pull-requests: write # to be able to comment on released pull requests
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "lts/*"
+      - name: Install dependencies
+        run: npm install semantic-release @semantic-release/{exec,git,github,changelog}
+      - name: Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npx semantic-release

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ coverage.*
 # Binary
 host-metering
 dist/host-metering
+node_modules

--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,43 @@
+{
+    "branches": [
+        "main"
+    ],
+    "plugins": [
+        "@semantic-release/commit-analyzer",
+        "@semantic-release/release-notes-generator",
+        [
+            "@semantic-release/exec",
+            {
+                "prepareCmd": "make version-update NEXT_VERSION=${nextRelease.version} ;",
+                "publishCmd": "make tarball"
+            }
+        ],
+        [
+            "@semantic-release/changelog",
+            {
+                "changelogFile": "CHANGELOG.md"
+            }
+        ],
+        [
+            "@semantic-release/git",
+            {
+                "assets": [
+                    "version/version.go",
+                    "CHANGELOG.md"
+                ],
+                "message": "build(release): ${nextRelease.version}\n\n${nextRelease.notes}"
+            }
+        ],
+        [
+            "@semantic-release/github",
+            {
+                "assets": [
+                    {
+                        "path": "dist/*.tar.gz",
+                        "label": "Tarball"
+                    }
+                ]
+            }
+        ]
+    ]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,139 @@
+# Contributing
+
+Open a pull request to contribute a change.
+
+The project is using
+- [Semantic Versioning](https://semver.org/)
+- [Semantic Release](https://semantic-release.gitbook.io/semantic-release/)
+- [Conventional Commits](https://www.conventionalcommits.org)
+## Commit message format
+Is defined by [Conventional Commits](https://www.conventionalcommits.org).
+Commit lint enforces the formatting rules on commit messages.
+
+The format is (source [Angular](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#-commit-message-format)
+project):
+
+Each commit message consists of a **header**, a **body**, and a **footer**.
+
+```
+<header>
+<BLANK LINE>
+<body>
+<BLANK LINE>
+<footer>
+```
+
+The `header` is mandatory and must conform to the [Commit Message Header](#commit-header) format.
+
+The `body` is mandatory for all commits except for those of type "docs".
+When the body is present it must be at least 20 characters long and must conform to the [Commit Message Body](#commit-body) format.
+
+The `footer` is optional. The [Commit Message Footer](#commit-footer) format describes what the footer is used for and the structure it must have.
+
+
+### <a name="commit-header"></a>Commit Message Header
+
+```
+<type>(<scope>): <short summary>
+  │       │             │
+  │       │             └─⫸ Summary in present tense. Not capitalized. No period at the end.
+  │       │
+  │       └─⫸ Commit Scope: config|selinux|rpm|daemon|hostinfo|notify|packaging|changelog|
+  |                          makefile
+  │
+  └─⫸ Commit Type: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test
+```
+
+The `<type>` and `<summary>` fields are mandatory, the `(<scope>)` field is optional.
+
+
+#### Type
+
+Must be one of the following:
+
+* **build**: Changes that affect the build system or external dependencies (example scopes: makefile)
+* **chore**: Other changes that don't modify src or test files
+* **ci**: Changes to our CI configuration files and scripts (examples: GitHub Actions)
+* **docs**: Documentation only changes
+* **feat**: A new feature
+* **fix**: A bug fix
+* **perf**: A code change that improves performance
+* **refactor**: A code change that neither fixes a bug nor adds a feature
+* **revert**: Reverts a previous commit
+* **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
+* **test**: Adding missing tests or correcting existing tests
+
+### <a name="commit-body"></a>Commit Message Body
+
+Just as in the summary, use the imperative, present tense: "fix" not "fixed" nor "fixes".
+
+Explain the motivation for the change in the commit message body. This commit message should explain _why_ you are making the change.
+You can include a comparison of the previous behavior with the new behavior in order to illustrate the impact of the change.
+
+### <a name="commit-footer"></a>Commit Message Footer
+
+The footer can contain information about breaking changes and deprecations and is also the place to reference GitHub issues, Jira tickets, and other PRs that this commit closes or is related to.
+For example:
+
+```
+BREAKING CHANGE: <breaking change summary>
+<BLANK LINE>
+<breaking change description + migration instructions>
+<BLANK LINE>
+<BLANK LINE>
+Fixes #<issue number>
+```
+
+or
+
+```
+DEPRECATED: <what is deprecated>
+<BLANK LINE>
+<deprecation description + recommended update path>
+<BLANK LINE>
+<BLANK LINE>
+Closes #<pr number>
+```
+
+Breaking Change section should start with the phrase "BREAKING CHANGE: " followed by a summary of the breaking change, a blank line, and a detailed description of the breaking change that also includes migration instructions.
+
+Similarly, a Deprecation section should start with "DEPRECATED: " followed by a short description of what is deprecated, a blank line, and a detailed description of the deprecation that also mentions the recommended update path.
+
+
+### Check commit message locally:
+
+```
+$ npm install commitlint@latest @commitlint/config-angular@latest
+$ npx commitlint --from HEAD~1
+```
+
+## Release
+
+Is using semantic release with semantic versioning.
+
+Semantic-release is configured in [.releaserc](.releaserc).
+
+It:
+- determines the current version based on git tags
+- determines the next version based on commit messages
+- bumps version in version/version.go
+- generates CHANGELOG.md update
+- commits the changes
+- creates a git tag
+- pushes the changes to the repo
+- makes a tarball with vendor dependencies included
+- creates a GitHub release with the tarball attached
+
+### Start a release
+
+1. Go to Actions tab on GitHub
+2. Run "Release" workflow.
+
+### Testing release
+
+It is a bit tricky to test the release process locally. It might be easier
+to do the changes, pushed them to your fork's main branch on GitHub and execute
+the release there.
+
+In local machine testing, make sure that the git repo has only your fork as
+the git remote to avoid accidental release in primary repo.

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 PROJECT := host-metering
 RPMNAME := host-metering
 VERSION := $(shell grep "Version" version/version.go | awk -F '"' '{print $$2}')
+NEXT_VERSION ?=
 SHORT_COMMIT ?= $(shell git rev-parse --short=8 HEAD)
 AUTORELEASE ?= "git$(shell date "+%Y%m%d%H%M")G$(SHORT_COMMIT)"
 
@@ -103,6 +104,12 @@ clean-pod:
 version:
 	@echo $(VERSION)
 
+.PHONY: version-update
+version-update:
+	@test -n "$(NEXT_VERSION)" || (echo "NEXT_VERSION is not set"; exit 1)
+	@echo "Updating the version to $(NEXT_VERSION)..."
+	sed -i "s/Version = \".*\"/Version = \"$(NEXT_VERSION)\"/" version/version.go
+
 .PHONY: distdir
 distdir:
 	@echo "Creating the destination directory..."
@@ -184,3 +191,11 @@ clean:
 	rm -rf $(CURDIR)/hack/cpumetrics
 	rm -f $(CURDIR)/hack/test-cert.crt
 	rm -f $(CURDIR)/hack/test-cert.key
+
+.PHONY: clean-node
+clean-node:
+	@echo "Cleaning the node..."
+	rm -rf $(CURDIR)/node_modules
+
+.PHONY: clean-all
+clean-all: clean clean-pod clean-node

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ See output/log:
 
 RPM builds of `main` branch are available at COPR:  https://copr.fedorainfracloud.org/coprs/pvoborni/host-metering/
 
+## Contribute
+
+See [CONTRIBUTING.md](CONTRIBUTING.md).
+
 ## Build
 
 ```

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,1 @@
+module.exports = {extends: ['@commitlint/config-conventional']};


### PR DESCRIPTION
See added CONTRIBUTING.md for details.

The purpose is to have 1-click release process done via GitHub actions.

This is achieved via semantic-release which does the whole release process. Version bump is derived from commit messages using semantic versioning. That requires commit messages to follow a specific structure and thus commit lint is added to ensure that all commits follow the structure.