### PR TITLE
fix: add external_organization label

### DIFF
--- a/hostinfo/info.go
+++ b/hostinfo/info.go
@@ -6,13 +6,14 @@ import (
 )
 
 type HostInfo struct {
-	CpuCount    uint
-	HostId      string
-	SocketCount string
-	Product     string
-	Support     string
-	Usage       string
-	Billing     BillingInfo
+	CpuCount             uint
+	HostId               string
+	ExternalOrganization string
+	SocketCount          string
+	Product              string
+	Support              string
+	Usage                string
+	Billing              BillingInfo
 }
 
 type BillingInfo struct {
@@ -57,6 +58,7 @@ func (hi *HostInfo) String() string {
 			"HostInfo:",
 			fmt.Sprintf("  CpuCount: %d", hi.CpuCount),
 			fmt.Sprintf("  HostId: %s", hi.HostId),
+			fmt.Sprintf("  ExternalOrganization: %s", hi.ExternalOrganization),
 			fmt.Sprintf("  SocketCount: %s", hi.SocketCount),
 			fmt.Sprintf("  Product: %s", hi.Product),
 			fmt.Sprintf("  Support: %s", hi.Support),

--- a/hostinfo/info_test.go
+++ b/hostinfo/info_test.go
@@ -23,6 +23,7 @@ func TestHostInfo(t *testing.T) {
 	expectedString := "HostInfo:\n" +
 		"  CpuCount: 64\n" +
 		"  HostId: 01234567-89ab-cdef-0123-456789abcdef\n" +
+		"  ExternalOrganization: 12345678\n" +
 		"  SocketCount: 3\n" +
 		"  Product: Red Hat Enterprise Linux Server\n" +
 		"  Support: Premium\n" +

--- a/hostinfo/subscription.go
+++ b/hostinfo/subscription.go
@@ -12,6 +12,7 @@ import (
 
 func LoadSubManInformation(hi *HostInfo) {
 	hi.HostId, _ = GetHostId()
+	hi.ExternalOrganization, _ = GetExternalOrganization()
 	hi.Usage, _ = GetUsage()
 	hi.Support, _ = GetServiceLevel()
 
@@ -25,6 +26,12 @@ func GetHostId() (string, error) {
 	output, _ := execSubManCommand("identity")
 	values := parseSubManOutput(output)
 	return values.get("system identity")
+}
+
+func GetExternalOrganization() (string, error) {
+	output, _ := execSubManCommand("identity")
+	values := parseSubManOutput(output)
+	return values.get("org ID")
 }
 
 func GetUsage() (string, error) {

--- a/hostinfo/subscription_test.go
+++ b/hostinfo/subscription_test.go
@@ -7,11 +7,12 @@ import (
 func TestLoadSubManInformation(t *testing.T) {
 	// Define the expected general host info.
 	expected := &HostInfo{
-		HostId:      "01234567-89ab-cdef-0123-456789abcdef",
-		SocketCount: "3",
-		Product:     "Red Hat Enterprise Linux Server",
-		Support:     "Premium",
-		Usage:       "Production",
+		HostId:               "01234567-89ab-cdef-0123-456789abcdef",
+		ExternalOrganization: "12345678",
+		SocketCount:          "3",
+		Product:              "Red Hat Enterprise Linux Server",
+		Support:              "Premium",
+		Usage:                "Production",
 	}
 
 	// Test the host info for AWS.

--- a/notify/prometheus.go
+++ b/notify/prometheus.go
@@ -178,6 +178,10 @@ func hostInfo2WriteRequest(hostinfo *hostinfo.HostInfo, samples []prompb.Sample)
 			Value: hostinfo.Billing.Model,
 		},
 		{
+			Name:  "external_organization",
+			Value: hostinfo.ExternalOrganization,
+		},
+		{
 			Name:  "product",
 			Value: hostinfo.Product,
 		},


### PR DESCRIPTION
It's a required label that was missing. Thus adding it.