### PR TITLE
fix: throw away samples on Prometheus Remote Write 4xx errors

### DIFF
--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -200,6 +201,33 @@ func TestNotify(t *testing.T) {
 		t.Fatalf("expected non-expired sample to be passed to notifier")
 	}
 
+	// Test that only expired samples are pruned on recoverable error
+	_, checkpoint, _ := metricsLog.GetSamples()
+	metricsLog.RemoveSamples(checkpoint)
+	expiredTs = time.Now().UnixMilli() - 11000
+	metricsLog.WriteSample(1, expiredTs)
+	metricsLog.WriteSampleNow(2)
+	notifier.ExpectError(notify.RecoverableError(fmt.Errorf("mocked")))
+	err = daemon.notify()
+	checkExpectedError(t, err, "recoverable notify error: mocked")
+	samples, _, _ = metricsLog.GetSamples()
+	if len(samples) != 1 {
+		t.Fatalf("expected expired sample to be pruned")
+	}
+	if samples[0].Value != 2 {
+		t.Fatalf("expected non-expired sample to be kept")
+	}
+
+	// Test that all samples are pruned on non-recoverable error
+	metricsLog.WriteSampleNow(2)
+	metricsLog.WriteSampleNow(2)
+	notifier.ExpectError(notify.NonRecoverableError(fmt.Errorf("mocked")))
+	err = daemon.notify()
+	checkExpectedError(t, err, "non-recoverable notify error: mocked")
+	samples, _, _ = metricsLog.GetSamples()
+	if len(samples) != 0 {
+		t.Fatalf("expected all samples to be pruned")
+	}
 }
 
 // Helper functions

--- a/notify/metricslog_test.go
+++ b/notify/metricslog_test.go
@@ -241,8 +241,9 @@ func createCorruptedMetrics(t *testing.T, path string) {
 }
 
 func checkError(t *testing.T, err error, message string) {
+	t.Helper()
 	if err != nil {
-		t.Fatalf("%s: %v", message, err)
+		t.Fatalf("%s: %v", message, err.Error())
 	}
 }
 

--- a/notify/notifier.go
+++ b/notify/notifier.go
@@ -1,11 +1,44 @@
 package notify
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/RedHatInsights/host-metering/hostinfo"
 	"github.com/prometheus/prometheus/prompb"
 )
+
+type NotifyError struct {
+	recoverable bool
+	wrappedErr  error
+}
+
+func (e *NotifyError) Error() string {
+	str := "non-recoverable notify error"
+	if e.recoverable {
+		str = "recoverable notify error"
+	}
+	if e.wrappedErr == nil {
+		return str
+	}
+	return fmt.Errorf("%s: %w", str, e.wrappedErr).Error()
+}
+
+func (e *NotifyError) Recoverable() bool {
+	return e.recoverable
+}
+
+func (e *NotifyError) Unwrap() error {
+	return e.wrappedErr
+}
+
+func RecoverableError(err error) *NotifyError {
+	return &NotifyError{recoverable: true, wrappedErr: err}
+}
+
+func NonRecoverableError(err error) *NotifyError {
+	return &NotifyError{recoverable: false, wrappedErr: err}
+}
 
 type Notifier interface {
 	Notify(samples []prompb.Sample, hostinfo *hostinfo.HostInfo) error

--- a/notify/notifier_test.go
+++ b/notify/notifier_test.go
@@ -1,6 +1,8 @@
 package notify
 
 import (
+	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -38,4 +40,27 @@ func TestFilterSamplesByAge(t *testing.T) {
 		t.Errorf("Expected 0 samples, got %d", len(filtered))
 	}
 
+}
+
+func TestNotifyError(t *testing.T) {
+	wrappedErr := RecoverableError(fmt.Errorf("wrapped"))
+
+	if wrappedErr.Error() != "recoverable notify error: wrapped" {
+		t.Errorf("Expected error message 'recoverable notify error: wrapped', got %s", wrappedErr.Error())
+	}
+
+	if wrappedErr.Recoverable() != true {
+		t.Errorf("Expected recoverable error, got non-recoverable")
+	}
+
+	wrappedErr = NonRecoverableError(fmt.Errorf("wrapped"))
+
+	if wrappedErr.Error() != "non-recoverable notify error: wrapped" {
+		t.Errorf("Expected error message 'non-recoverable notify error: wrapped', got %s", wrappedErr.Error())
+	}
+
+	err := errors.Unwrap(wrappedErr)
+	if err.Error() != "wrapped" {
+		t.Errorf("Expected error message 'wrapped', got %s", err.Error())
+	}
 }


### PR DESCRIPTION
This change adds concept of Recoverable and Non-Recoverable error in Notifier interface. Deamon throws away the samples on non-recoverable error.

PrometheusNotifier was modified to produce Non-recoverable error on 4xx http error family and on unknown http errors. This should be in complience with prometheus remote write spec as the client should not retry on 4xx except on 429.

This also means that host-metering will throw away samples from time when
- it was misconfigured with wrong URL (404)
- auth issue happened (403)

It doesn't throw away samples on connectivity issues (no response from server).