### PR TITLE
fix: dropping of expired samples

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -236,7 +236,7 @@ func (d *Daemon) notify() error {
 		logger.Warnf("Notification: %s\n", err.Error())
 		if origCount != count {
 			logger.Infof("Dropping %d expired sample(s)\n", origCount-count)
-			truncateError = d.metricsLog.RemoveSamples(checkpoint - uint64(count))
+			truncateError = d.metricsLog.RemoveOldestSamples(origCount - count)
 		}
 	}
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -235,6 +235,7 @@ func (d *Daemon) notify() error {
 		// on recoverable or unknowns errors
 		logger.Warnf("Notification: %s\n", err.Error())
 		if origCount != count {
+			logger.Infof("Dropping %d expired sample(s)\n", origCount-count)
 			truncateError = d.metricsLog.RemoveSamples(checkpoint - uint64(count))
 		}
 	}

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -208,13 +208,22 @@ func TestNotify(t *testing.T) {
 	metricsLog.RemoveSamples(checkpoint)
 	expiredTs = time.Now().UnixMilli() - 11000
 	metricsLog.WriteSample(1, expiredTs)
+	_, _, _ = metricsLog.GetSamples()
+	metricsLog.WriteSample(1, expiredTs)
+	_, _, _ = metricsLog.GetSamples()
 	metricsLog.WriteSampleNow(2)
+	_, _, _ = metricsLog.GetSamples()
+	metricsLog.WriteSampleNow(3)
+	_, _, _ = metricsLog.GetSamples()
+	metricsLog.WriteSampleNow(4)
+	_, _, _ = metricsLog.GetSamples()
+	metricsLog.WriteSampleNow(5)
 	notifier.ExpectError(notify.RecoverableError(fmt.Errorf("mocked")))
 	err = daemon.notify()
 	checkExpectedError(t, err, "recoverable notify error: mocked")
 	samples, _, _ = metricsLog.GetSamples()
-	if len(samples) != 1 {
-		t.Fatalf("expected expired sample to be pruned")
+	if len(samples) != 4 {
+		t.Fatalf("expected expired sample to be pruned, got %d", len(samples))
 	}
 	if samples[0].Value != 2 {
 		t.Fatalf("expected non-expired sample to be kept")

--- a/hack/host-metering.conf
+++ b/hack/host-metering.conf
@@ -15,4 +15,5 @@ write_timeout_sec=1
 write_retry_attempts=1
 write_retry_max_int_sec=2
 metrics_wal_path=./hack/cpumetrics
+metrics_max_age_sec=30
 log_level=DEBUG


### PR DESCRIPTION
**fix: log dropping of expired samples on INFO level**

So that it is clearly visible even on INFO level - as this should be
unusual situation.

**fix: dropping of expired samples**

Dropping of expired samples did not work correctly. It was truncating to
index: "lastIndex - number of non-expired samples" but this  might not
be the correct index as samples are often interlanced with checkpoints,
e.g. imagine wal:

    0: checkpoint
    1: sample 1 (now expired)
    2: checkpoint
    3: sample 2 (now expired)
    4: checkpoint
    5: sample 3
    6: checkpoint
    7: sample 4
    8: checkpoint
    9: sample 5
10: checkpoint
11: sample 6
12: checkpoint
13: sample 7
14: checkpoint:

removal of expired would be: 14 - 5 = 9, as:
- checkpoint: 14
- number of non-expired samples: 5

i.e. on recoverable failure it would drop samples up to sample 5(index
9) but it should drop only upto to index after sample 2 (index 4).

This patch in introducing a new method which traverses WAL and finds to
index after number of samples to remove - to behave as expected.