### PR TITLE
fix: stop/restart on rpm uninstall/update, remove selinux policy on rpm uninstall

### DIFF
--- a/contrib/rpm/host-metering.spec.in
+++ b/contrib/rpm/host-metering.spec.in
@@ -82,6 +82,9 @@ install -D -p -m 644 contrib/selinux/%{modulename}.if %{buildroot}%{_datadir}/se
 %check
 %endif
 
+%post
+/bin/systemctl --system daemon-reload 2>&1 || :
+
 %post selinux
 %selinux_modules_install -s %{selinuxtype} %{_datadir}/selinux/packages/%{selinuxtype}/%{modulename}.pp
 %selinux_relabel_post -s %{selinuxtype}
@@ -89,6 +92,21 @@ install -D -p -m 644 contrib/selinux/%{modulename}.if %{buildroot}%{_datadir}/se
 if [ "$1" -le "1" ]; then # First install
    # the daemon needs to be restarted for the custom label to be applied
    %systemd_postun_with_restart %{modulename}.service
+fi
+
+%posttrans
+# restart on upgrade if was enabled
+/bin/systemctl is-enabled host-metering.service >/dev/null 2>&1
+if [  $? -eq 0 ]; then
+    /bin/systemctl restart host-metering.service >/dev/null || :
+fi
+
+
+%preun
+# stop and disable on uninstallation
+if [ $1 -eq 0 ]; then
+    /bin/systemctl --quiet stop host-metering.service || :
+    /bin/systemctl --quiet disable host-metering.service || :
 fi
 
 %postun selinux

--- a/contrib/rpm/host-metering.spec.in
+++ b/contrib/rpm/host-metering.spec.in
@@ -51,6 +51,7 @@ Host metering service
 Summary:       SELinux policy module for host-metering
 BuildArch:     noarch
 %{?selinux_requires}
+Requires:      %{name} = %{version}-%{release}
 
 %description selinux
 This package installs and sets up the SELinux policy security module for host-metering.


### PR DESCRIPTION
**fix: stop service on uninstallation and restart on upgrade**

Fix rpm scriplets so that host-metering service:
* is restarted on upgrade to run with new code
* stopped and disabled on uninstallation

**fix: remove host-metering-selinux on uninstall of host-metering**

So that the following works symmetrically:

```
yum install host-metering # installs also host-metering-selinux
yum remove host-metering  # also removes it
```