### PR TITLE
feat: add prometheus recording rule to aggregate measurements

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -8,15 +8,38 @@ services:
     volumes:
       - ../:/workspace/host-metering:Z
 
+  prometheus-rules-generator:
+    image: docker.io/mikefarah/yq:latest
+    volumes:
+      - ../contrib/prometheus:/workdir:Z
+    entrypoint: sh
+    command:
+      - -c
+      - "yq .objects[0].spec /workdir/recording-rules-resource.yml > /workdir/recording-rules.yml"
+    userns_mode: host
+    user: root
+
   prometheus:
     image: prometheus/prometheus
     ports:
       - 9090:9090
     volumes:
       - ./local_prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:Z
+      - ../contrib/prometheus:/etc/prometheus/contrib:Z
     command:
       -  '--config.file=/etc/prometheus/prometheus.yml'
       -  '--storage.tsdb.path=/prometheus'
       -  '--web.console.libraries=/usr/share/prometheus/console_libraries'
       -  '--web.console.templates=/usr/share/prometheus/consoles'
       -  '--web.enable-remote-write-receiver'
+    depends_on:
+      prometheus-rules-generator:
+        condition: service_completed_successfully
+
+  promtool:
+    # share common volume configuration with prometheus service
+    extends:
+      service: prometheus
+    image: dnanexus/promtool:2.9.2
+    ports: []
+    command: check config /etc/prometheus/prometheus.yml

--- a/.devcontainer/local_prometheus/prometheus.yml
+++ b/.devcontainer/local_prometheus/prometheus.yml
@@ -1,1 +1,3 @@
 ---
+rule_files:
+  - ./contrib/recording-rules.yml

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ mocks/consumer/
 mocks/cpumetrics/
 .devcontainer/docker-compose.local.yml
 coverage.*
+contrib/prometheus/recording-rules.yml

--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,10 @@ prometheus-stop:
 podman-%:
 	podman-compose -f .devcontainer/docker-compose.yml run -u root host-metering bash -c "cd /workspace/host-metering && make $(subst podman-,,$@)"
 
+.PHONY: promtool-check-config
+promtool-check-config:
+	podman-compose -f .devcontainer/docker-compose.yml up promtool
+
 .PHONY: clean-pod
 clean-pod:
 	podman-compose -f .devcontainer/docker-compose.yml down

--- a/contrib/prometheus/recording-rules-resource.yml
+++ b/contrib/prometheus/recording-rules-resource.yml
@@ -1,0 +1,17 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: host-metering-rules-template
+objects:
+- apiVersion: monitoring.coreos.com/v1
+  kind: PrometheusRule
+  metadata:
+    labels:
+      tenant: rhel
+    name: host-metering-recording-rules
+  spec:
+    groups:
+      - name: host-metering
+        rules:
+          - record: host:usage:workload:cpu_hours1h
+            expr:  max by(_id) (sum_over_time(system_cpu_logical_count[1h:10m])) / scalar(count_over_time(vector(1)[1h:10m]))


### PR DESCRIPTION
Added a rules file to create a recording rule that aggregates the metric sent by the `host-metering` client to indicate CPU hours on a per-hour resolution.

As part of the process changed the configuration of the local prometheus container to use the aggregated metric and added a makefile action to lint the prometheus configuration.