### PR TITLE
feat: configurable log prefix

### DIFF
--- a/.devcontainer/host-metering.conf
+++ b/.devcontainer/host-metering.conf
@@ -18,3 +18,4 @@ write_retry_max_int_sec=2
 metrics_wal_path=./mocks/cpumetrics
 metrics_max_age_sec=30
 log_level=DEBUG
+log_prefix=%S

--- a/config/config.go
+++ b/config/config.go
@@ -25,6 +25,7 @@ const (
 	DefaultMetricsWALPath       = "/var/run/host-metering/metrics"
 	DefaultLogLevel             = "INFO"
 	DefaultLogPath              = "" //Default to stderr, will be logged in journal.
+	DefaultLogPrefix            = ""
 )
 
 type Config struct {
@@ -42,6 +43,7 @@ type Config struct {
 	MetricsWALPath       string
 	LogLevel             string // one of "ERROR", "WARN", "INFO", "DEBUG", "TRACE"
 	LogPath              string
+	LogPrefix            string
 }
 
 func NewConfig() *Config {
@@ -60,6 +62,7 @@ func NewConfig() *Config {
 		MetricsWALPath:       DefaultMetricsWALPath,
 		LogLevel:             DefaultLogLevel,
 		LogPath:              DefaultLogPath,
+		LogPrefix:            DefaultLogPrefix,
 	}
 }
 
@@ -81,6 +84,7 @@ func (c *Config) String() string {
 			fmt.Sprintf("|  MetricsWALPath: %s", c.MetricsWALPath),
 			fmt.Sprintf("|  LogLevel: %s", c.LogLevel),
 			fmt.Sprintf("|  LogPath: %s", c.LogPath),
+			fmt.Sprintf("|  LogPrefix: %s", c.LogPrefix),
 		}, "\n")
 }
 
@@ -137,6 +141,9 @@ func (c *Config) UpdateFromEnvVars() error {
 	}
 	if v := os.Getenv("HOST_METERING_LOG_PATH"); v != "" {
 		c.LogPath = v
+	}
+	if v := os.Getenv("HOST_METERING_LOG_PREFIX"); v != "" {
+		c.LogPrefix = v
 	}
 	return multiError.ErrorOrNil()
 }
@@ -251,6 +258,9 @@ func (c *Config) UpdateFromConfigFile(path string) error {
 	}
 	if v, ok := config[section]["log_path"]; ok {
 		c.LogPath = v
+	}
+	if v, ok := config[section]["log_prefix"]; ok {
+		c.LogPrefix = v
 	}
 
 	return multiError.ErrorOrNil()

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -25,7 +25,8 @@ func TestDefaultConfig(t *testing.T) {
 		"|  MetricsMaxAgeSec: 5400\n" +
 		"|  MetricsWALPath: /var/run/host-metering/metrics\n" +
 		"|  LogLevel: INFO\n" +
-		"|  LogPath: \n"
+		"|  LogPath: \n" +
+		"|  LogPrefix: \n"
 
 	// Create the default configuration.
 	c := NewConfig()
@@ -71,7 +72,8 @@ func TestConfigFile(t *testing.T) {
 		"|  MetricsMaxAgeSec: 700\n" +
 		"|  MetricsWALPath: /tmp/metrics\n" +
 		"|  LogLevel: ERROR\n" +
-		"|  LogPath: /tmp/log\n"
+		"|  LogPath: /tmp/log\n" +
+		"|  LogPrefix: %d%t\n"
 
 	// Update the configuration from a valid config file.
 	fileContent := "[host-metering]\n" +
@@ -90,7 +92,8 @@ func TestConfigFile(t *testing.T) {
 		"metrics_max_age_sec = 700\n" +
 		"metrics_wal_path = /tmp/metrics\n" +
 		"log_level = ERROR\n" +
-		"log_path = /tmp/log\n"
+		"log_path = /tmp/log\n" +
+		"log_prefix = %d%t\n"
 
 	c := NewConfig()
 
@@ -148,7 +151,8 @@ func TestEnvVariables(t *testing.T) {
 		"|  MetricsMaxAgeSec: 700\n" +
 		"|  MetricsWALPath: /tmp/metrics\n" +
 		"|  LogLevel: ERROR\n" +
-		"|  LogPath: /tmp/log\n"
+		"|  LogPath: /tmp/log\n" +
+		"|  LogPrefix: %d\n"
 
 	// Set valid environment variables.
 	t.Setenv("HOST_METERING_WRITE_URL", "http://test/url")
@@ -165,6 +169,7 @@ func TestEnvVariables(t *testing.T) {
 	t.Setenv("HOST_METERING_METRICS_WAL_PATH", "/tmp/metrics")
 	t.Setenv("HOST_METERING_LOG_LEVEL", "ERROR")
 	t.Setenv("HOST_METERING_LOG_PATH", "/tmp/log")
+	t.Setenv("HOST_METERING_LOG_PREFIX", "%d")
 
 	// Environment variables are set. Change the defaults.
 	c := NewConfig()
@@ -218,6 +223,7 @@ func clearEnvironment() {
 	_ = os.Unsetenv("HOST_METERING_METRICS_WAL_PATH")
 	_ = os.Unsetenv("HOST_METERING_LOG_LEVEL")
 	_ = os.Unsetenv("HOST_METERING_LOG_PATH")
+	_ = os.Unsetenv("HOST_METERING_LOG_PREFIX")
 }
 
 func checkError(t *testing.T, err error, message string) {

--- a/contrib/man/host-metering.1
+++ b/contrib/man/host-metering.1
@@ -86,6 +86,49 @@ Log level. Possible values are: DEBUG, INFO, WARN, ERROR, TRACE.
 \fBHOST_METERING_LOG_PATH\fR
 Path to log file. Default is empty - stderr.
 
+\fBHOST_METERING_LOG_PREFIX\fR
+Prefix of log messages. Default is empty. Format: "[PREFIX][FLAG]*"
+
+.RS 4
+
+\fBPREFIX:\fR string until first occurance of %
+
+\fBFLAGS:\fR
+.RS 4
+.TP
+.B %d
+Date
+
+.TP
+.B %t
+Time
+
+.TP
+.B %m
+Microseconds
+
+.TP
+.B %l
+Long file name
+
+.TP
+.B %s
+Short file name
+
+.TP
+.B %z
+Use UTC
+
+.TP
+.B %p
+Move the "PREFIX" from the beginning of the line to before the message
+
+.TP
+.B %S
+Datetime (same as "%d %t")
+.RE
+.RE
+
 .SH "FILES"
 .PP
 \fI/etc/host-metering.conf\fR

--- a/contrib/man/host-metering.conf.5
+++ b/contrib/man/host-metering.conf.5
@@ -98,6 +98,49 @@ log_path (string)
 Path to log file. Default is empty - stderr.
 .RE
 
+.PP
+log_prefix (string)
+.RS 4
+Prefix of log messages. Default is empty. Format: "[PREFIX][FLAG]*"
+
+\fBPREFIX:\fR string until first occurance of %
+
+\fBFLAGS:\fR
+.RS 4
+.TP
+.B %d
+Date
+
+.TP
+.B %t
+Time
+
+.TP
+.B %m
+Microseconds
+
+.TP
+.B %l
+Long file name
+
+.TP
+.B %s
+Short file name
+
+.TP
+.B %z
+Use UTC
+
+.TP
+.B %p
+Move the "PREFIX" from the beginning of the line to before the message
+
+.TP
+.B %S
+Datetime (same as "%d %t")
+.RE
+.RE
+
 .SH "EXAMPLES"
 .PP
 1\&. The following example shows how to switch the logging to DEBUG level\&.

--- a/main.go
+++ b/main.go
@@ -47,7 +47,8 @@ func main() {
 		}
 
 		// initialize the logger according to the given configuration
-		err = logger.InitLogger(cfg.LogPath, cfg.LogLevel)
+		logPrefix, logFlag := logger.ParseLogPrefix(cfg.LogPrefix)
+		err = logger.InitLogger(cfg.LogPath, cfg.LogLevel, logPrefix, logFlag)
 
 		if err != nil {
 			logger.Debugf("Error initializing logger: %s\n", err.Error())


### PR DESCRIPTION
For adjusting prefix of output, e.g. to add prefix string or log formatting flags.

Format:
- prefix: string until first occurance of %
- flag: combination of flags

Flags:
- %d - date
- %t - time
- %m - microseconds
- %l - long file name
- %s - short file name
- %z - use UTC
- %p - move the "prefix" from the beginning of the line to before the message
- %S - datetime  - same as "%d %t"

Basically the meaning is the same as in std log library:
  https://pkg.go.dev/log#pkg-constants