### PR TITLE
test: fix race condition in daemon_test

### DIFF
--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -246,7 +246,7 @@ func TestRunWithLabelRefresh(t *testing.T) {
 	daemon.config.LabelRefreshInterval = 5 * time.Millisecond
 
 	go daemon.Run()
-	checkRunning(t, daemon)
+	waitForStarted(t, daemon)
 
 	// Check initial labels are set to Mock default
 	if daemon.hostInfo.Product != "testproduct" || daemon.hostInfo.Support != "testsupport" {
@@ -265,7 +265,7 @@ func TestRunWithLabelRefresh(t *testing.T) {
 	newHostInfo.ResetCalled()
 	newHostInfo.WaitForCalled(t, 1)
 	if daemon.hostInfo.Product != "anotherproduct" || daemon.hostInfo.Support != "premium" {
-		t.Fatalf("expected label refresh on label refresh interval")
+		t.Fatalf("expected label refresh on label refresh interval, got: %s, %s", daemon.hostInfo.Product, daemon.hostInfo.Support)
 	}
 
 	// Cleanup
@@ -278,7 +278,7 @@ func TestRunWithoutLabelRefresh(t *testing.T) {
 	daemon.config.LabelRefreshInterval = 0
 
 	go daemon.Run()
-	checkRunning(t, daemon)
+	waitForStarted(t, daemon)
 
 	// Check initial labels are set to Mock default
 	if daemon.hostInfo.Product != "testproduct" || daemon.hostInfo.Support != "testsupport" {
@@ -587,6 +587,7 @@ func (m *mockHostInfoProvider) WaitForCalled(t *testing.T, n uint) {
 	start := time.Now()
 	for {
 		if m.called == n {
+			time.Sleep(100 * time.Microsecond)
 			return
 		}
 		if time.Since(start) > 10*time.Millisecond {


### PR DESCRIPTION
This patch stabilizes newly added TestRunWithLabelRefresh and TestRunWithoutLabelRefresh by using waitForStarted to ensure that first load of HostInfo has happened before new is changed.

And especially it adds a little wait to `WaitForCalled` to solve a race condition where a test code might check new HostInfo when it was not yet replaced with the newly loaded one. This also fixes `TestReloadOnCertChange` test which has also failed when the suite was run 1000 times.

With this code, `go test --failfast --count 1000  ./daemon/` was successful on my test vm.