### PR TITLE
test: fix daemon test compilation issue

### DIFF
--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -249,13 +249,13 @@ func TestRunWithLabelRefresh(t *testing.T) {
 	waitForStarted(t, daemon)
 
 	// Check initial labels are set to Mock default
-	if daemon.hostInfo.Product != "testproduct" || daemon.hostInfo.Support != "testsupport" {
+	if daemon.hostInfo.Usage != "testusage" || daemon.hostInfo.Support != "testsupport" {
 		t.Fatalf("expected initial mock labels")
 	}
 
 	// Change the HostInfoProvider Mock to return a predictable HostInfo after label refresh
 	newHostInfo := newMockHostInfoProvider(&hostinfo.HostInfo{
-		Product: "anotherproduct",
+		Usage:   "anotherusage",
 		Support: "premium",
 	})
 
@@ -264,7 +264,7 @@ func TestRunWithLabelRefresh(t *testing.T) {
 	// Label refresh on label refresh interval
 	newHostInfo.ResetCalled()
 	newHostInfo.WaitForCalled(t, 1)
-	if daemon.hostInfo.Product != "anotherproduct" || daemon.hostInfo.Support != "premium" {
+	if daemon.hostInfo.Usage != "anotherusage" || daemon.hostInfo.Support != "premium" {
 		t.Fatalf("expected label refresh on label refresh interval, got: %s, %s", daemon.hostInfo.Product, daemon.hostInfo.Support)
 	}
 
@@ -281,19 +281,19 @@ func TestRunWithoutLabelRefresh(t *testing.T) {
 	waitForStarted(t, daemon)
 
 	// Check initial labels are set to Mock default
-	if daemon.hostInfo.Product != "testproduct" || daemon.hostInfo.Support != "testsupport" {
+	if daemon.hostInfo.Usage != "testusage" || daemon.hostInfo.Support != "testsupport" {
 		t.Fatalf("expected initial mock labels")
 	}
 
 	// Change the HostInfoProvider Mock to return a predictable HostInfo after label refresh
 	daemon.hostInfoProvider = newMockHostInfoProvider(&hostinfo.HostInfo{
-		Product: "anotherproduct",
+		Usage:   "anotherusage",
 		Support: "premium",
 	})
 
 	// Wait for more than LabelRefreshInterval and check labels
 	time.Sleep(20 * time.Millisecond)
-	if daemon.hostInfo.Product != "testproduct" || daemon.hostInfo.Support != "testsupport" {
+	if daemon.hostInfo.Usage != "testusage" || daemon.hostInfo.Support != "testsupport" {
 		t.Fatalf("expected labels not to be refreshed")
 	}
 


### PR DESCRIPTION
PR with commit 5f5e552abb5de46981fa9324341850b41eb1e937 was created before commit 6cf0df3506aee8819aa9e1abd4c7bb4f38c3e23e but the latter commit was merged first and the first was not rebased. The former changed data type of `Product` which was used by latter. Thus tests introduced by latter could not be compiled.

This fix is changing the tests from the latter to use a different field so that it doesn't need to compare slices and thus fixing the datatype issue.