### PR TITLE
fix: log file permissions

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -97,7 +97,7 @@ func InitLogger(file string, level string, prefix string, flag int) error {
 
 	logFile := os.Stderr
 	if file != "" {
-		logFile, err = os.OpenFile(file, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0755)
+		logFile, err = os.OpenFile(file, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
 	}
 	if err != nil {
 		return err


### PR DESCRIPTION
Change created log to not be "executable" and secure by default, i.e. 755 -> 600.

This is used when `log_path` is configured.