### PR TITLE
build: do not use go macros in rpm build

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,32 @@
+---
+# See the documentation for more information:
+# https://packit.dev/docs/configuration/
+
+specfile_path: contrib/rpm/host-metering.spec
+upstream_package_name: host-metering
+downstream_package_name: host-metering
+upstream_tag_template: "v{version}"
+srpm_build_deps:
+  - git
+  - make
+  - curl
+  - gzip
+  - tar
+  - rpm-build
+  - golang
+
+actions:
+  create-archive:
+    - "make tarball"
+    - "sh -c 'echo dist/host-metering-$(make version).tar.gz'"
+
+  get-current-version:
+    - "make version"
+
+  post-upstream-clone:
+    - "make rpm/spec"
+
+jobs:
+- job: copr_build
+  trigger: pull_request
+  targets: [fedora-stable, epel-7-x86_64, rhel-8-x86_64, rhel-9-x86_64]

--- a/contrib/rpm/host-metering.spec.in
+++ b/contrib/rpm/host-metering.spec.in
@@ -26,7 +26,7 @@ Summary:        None
 
 License:        Apache-2.0
 ExcludeArch:    %{ix86} s390 ppc ppc64
-URL:            %{gourl}
+URL:            https://github.com/RedHatInsights/host-metering/
 
 Source:         %{name}-%{version}.tar.gz
 

--- a/contrib/rpm/host-metering.spec.in
+++ b/contrib/rpm/host-metering.spec.in
@@ -45,8 +45,6 @@ Requires:      %{name}-selinux = %{version}-%{release}
 %description
 Host metering service
 
-%gopkg
-
 %package selinux
 Summary:       SELinux policy module for host-metering
 BuildArch:     noarch


### PR DESCRIPTION
**build: do not use %gopkg**

The macro is not defined on RHEL/CentOS/EL 7.

The original idea was to wrap it with some `if 0%{?rhel} > 7 || 0%{?fedora}`
but this was failing in `packit srpm`.

The %gopkg is producing the host-metering-debugsource package, this is
not critical and thus is was removed. Individual downstreams can add it
if needed.

**build: set explicit URL in rpm spec**

As %gourl macro does not work on RHEL 7.

Rebased on top of https://github.com/RedHatInsights/host-metering/pull/31 to get rpms built.