### PR TITLE
feat: send display_name label with host's name/fqdn

### DIFF
--- a/hostinfo/info.go
+++ b/hostinfo/info.go
@@ -8,6 +8,7 @@ import (
 type HostInfo struct {
 	CpuCount             uint
 	HostId               string
+	HostName             string
 	ExternalOrganization string
 	SocketCount          string
 	Product              []string
@@ -58,6 +59,7 @@ func (hi *HostInfo) String() string {
 		[]string{
 			"HostInfo:",
 			fmt.Sprintf("|  CpuCount: %d", hi.CpuCount),
+			fmt.Sprintf("|  HostName: %s", hi.HostName),
 			fmt.Sprintf("|  HostId: %s", hi.HostId),
 			fmt.Sprintf("|  ExternalOrganization: %s", hi.ExternalOrganization),
 			fmt.Sprintf("|  SocketCount: %s", hi.SocketCount),

--- a/hostinfo/info_test.go
+++ b/hostinfo/info_test.go
@@ -22,6 +22,7 @@ func TestHostInfo(t *testing.T) {
 	// Define the expected defaults.
 	expectedString := "HostInfo:\n" +
 		"|  CpuCount: 64\n" +
+		"|  HostName: host.mock.test\n" +
 		"|  HostId: 01234567-89ab-cdef-0123-456789abcdef\n" +
 		"|  ExternalOrganization: 12345678\n" +
 		"|  SocketCount: 3\n" +

--- a/hostinfo/subscription.go
+++ b/hostinfo/subscription.go
@@ -13,6 +13,7 @@ import (
 func LoadSubManInformation(hi *HostInfo) {
 	identity := GetSubManIdentity()
 	hi.HostId, _ = GetHostId(identity)
+	hi.HostName, _ = GetHostName(identity)
 	hi.ExternalOrganization, _ = GetExternalOrganization(identity)
 
 	hi.Usage, _ = GetUsage()
@@ -32,6 +33,10 @@ func GetSubManIdentity() SubManValues {
 
 func GetHostId(identity SubManValues) (string, error) {
 	return identity.get("system identity")
+}
+
+func GetHostName(identity SubManValues) (string, error) {
+	return identity.get("name")
 }
 
 func GetExternalOrganization(identity SubManValues) (string, error) {

--- a/hostinfo/subscription_test.go
+++ b/hostinfo/subscription_test.go
@@ -9,6 +9,7 @@ func TestLoadSubManInformation(t *testing.T) {
 	// Define the expected general host info.
 	expected := &HostInfo{
 		HostId:               "01234567-89ab-cdef-0123-456789abcdef",
+		HostName:             "host.mock.test",
 		ExternalOrganization: "12345678",
 		SocketCount:          "3",
 		Product:              []string{"394", "69"},

--- a/mocks/subscription-manager
+++ b/mocks/subscription-manager
@@ -4,7 +4,7 @@
 
 IDENTITY=\
 "system identity: 01234567-89ab-cdef-0123-456789abcdef
-name: hostname
+name: host.mock.test
 org name: 12345678
 org ID: 12345678"
 

--- a/notify/prometheus.go
+++ b/notify/prometheus.go
@@ -184,6 +184,10 @@ func hostInfo2WriteRequest(hostinfo *hostinfo.HostInfo, samples []prompb.Sample)
 			Value: hostinfo.ConversionsSuccess,
 		},
 		{
+			Name:  "display_name",
+			Value: hostinfo.HostName,
+		},
+		{
 			Name:  "external_organization",
 			Value: hostinfo.ExternalOrganization,
 		},

--- a/notify/prometheus_test.go
+++ b/notify/prometheus_test.go
@@ -293,6 +293,7 @@ func TestLabels(t *testing.T) {
 		"billing_marketplace_instance_id",
 		"billing_model",
 		"conversions_success",
+		"display_name",
 		"external_organization",
 		"product",
 		"socket_count",
@@ -490,6 +491,7 @@ func createHostInfo() *hostinfo.HostInfo {
 	return &hostinfo.HostInfo{
 		CpuCount:             1,
 		HostId:               "test",
+		HostName:             testHostname,
 		SocketCount:          "1",
 		Product:              []string{"123", "456"},
 		Support:              "test support",


### PR DESCRIPTION
Which is read from "subscription-manager identity" command, attribute "name".

So that it is easier to identify the metered host by humans.