### PR TITLE
[HMS-3279]  fix: `subscription-manager list --installed` call failure

### DIFF
--- a/hostinfo/subscription.go
+++ b/hostinfo/subscription.go
@@ -119,6 +119,7 @@ func execSubManCommand(command string) (string, error) {
 
 	if err != nil {
 		err = fmt.Errorf("`subscription-manager %s` has failed: %s", command, err.Error())
+		logger.Debugf("Stdout: %s\n", strings.TrimSpace(stdout.String()))
 		logger.Debugf("Stderr: %s\n", strings.TrimSpace(stderr.String()))
 		logger.Errorf("Error executing subscription manager: %s", err.Error())
 		return "", err

--- a/hostinfo/subscription.go
+++ b/hostinfo/subscription.go
@@ -65,7 +65,7 @@ func GetSocketCount(facts SubManValues) (string, error) {
 }
 
 func GetProduct(facts SubManValues) ([]string, error) {
-	output, _ := execSubManCommand("list --installed")
+	output, _ := execSubManCommand("list", "--installed")
 	values := parseSubManOutputMultiVal(output)
 	return values.get("Product ID")
 }
@@ -109,8 +109,8 @@ func GetBillingInfo(facts SubManValues) (BillingInfo, error) {
 	return BillingInfo{}, err
 }
 
-func execSubManCommand(command string) (string, error) {
-	cmd := exec.Command("subscription-manager", command)
+func execSubManCommand(command ...string) (string, error) {
+	cmd := exec.Command("subscription-manager", command...)
 	logger.Debugf("Executing `subscription-manager %s`...\n", command)
 
 	var stdout, stderr bytes.Buffer

--- a/mocks/subscription-manager
+++ b/mocks/subscription-manager
@@ -215,10 +215,12 @@ hard_coded() {
       show_facts
       ;;
     list)
-      show_list_installed
-      ;;
-    "list --installed")
-      show_list_installed
+      if [ "${2}" == "--installed" ]; then
+        show_list_installed
+      else
+        echo "Unsupported command: ${command}" >&2
+        exit 1
+      fi
       ;;
     *)
       echo "Unsupported command: ${command}" >&2


### PR DESCRIPTION
**fix: log subscription-manager stdout on error**

To be able to easier investigate subscription-manager run failures.

**fix: `subscription-manager list --installed` call failure.**

The `subscription-manager list --installed` was failing with RC 1, after
printing stdout it visible that it reported that it was called
incorrectly and thus printed help text.

Issue was caused by the way how parameters were passed, now each is
passed separately as the exec.Command expects it.

https://issues.redhat.com/browse/HMS-3279