### PR TITLE
[HMS-3264] feat: Optional `display_name` label

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -18,6 +18,7 @@ func TestDefaultConfig(t *testing.T) {
 		"|  HostCertKeyPath: /etc/pki/consumer/key.pem\n" +
 		"|  CollectIntervalSec: 0\n" +
 		"|  LabelRefreshIntervalSec: 86400\n" +
+		"|  SendHostname: yes\n" +
 		"|  WriteRetryAttempts: 8\n" +
 		"|  WriteRetryMinIntSec: 1\n" +
 		"|  WriteRetryMaxIntSec: 10\n" +
@@ -65,6 +66,7 @@ func TestConfigFile(t *testing.T) {
 		"|  HostCertKeyPath: /tmp/key.pem\n" +
 		"|  CollectIntervalSec: 20\n" +
 		"|  LabelRefreshIntervalSec: 300\n" +
+		"|  SendHostname: no\n" +
 		"|  WriteRetryAttempts: 4\n" +
 		"|  WriteRetryMinIntSec: 5\n" +
 		"|  WriteRetryMaxIntSec: 6\n" +
@@ -85,6 +87,7 @@ func TestConfigFile(t *testing.T) {
 		"collect_interval_sec = 20\n" +
 		"; And also these comments.\n" +
 		"label_refresh_interval_sec = 300\n" +
+		"send_hostname = no\n" +
 		"write_retry_attempts = 4\n" +
 		"write_retry_min_int_sec = 5\n" +
 		"write_retry_max_int_sec = 6\n" +
@@ -144,6 +147,7 @@ func TestEnvVariables(t *testing.T) {
 		"|  HostCertKeyPath: /tmp/key.pem\n" +
 		"|  CollectIntervalSec: 20\n" +
 		"|  LabelRefreshIntervalSec: 300\n" +
+		"|  SendHostname: no\n" +
 		"|  WriteRetryAttempts: 4\n" +
 		"|  WriteRetryMinIntSec: 5\n" +
 		"|  WriteRetryMaxIntSec: 6\n" +
@@ -160,6 +164,7 @@ func TestEnvVariables(t *testing.T) {
 	t.Setenv("HOST_METERING_HOST_CERT_PATH", "/tmp/cert.pem")
 	t.Setenv("HOST_METERING_HOST_CERT_KEY_PATH", "/tmp/key.pem")
 	t.Setenv("HOST_METERING_COLLECT_INTERVAL_SEC", "20")
+	t.Setenv("HOST_METERING_SEND_HOSTNAME", "no")
 	t.Setenv("HOST_METERING_LABEL_REFRESH_INTERVAL_SEC", "300")
 	t.Setenv("HOST_METERING_WRITE_RETRY_ATTEMPTS", "4")
 	t.Setenv("HOST_METERING_WRITE_RETRY_MIN_INT_SEC", "5")
@@ -214,6 +219,7 @@ func clearEnvironment() {
 	_ = os.Unsetenv("HOST_METERING_HOST_CERT_PATH")
 	_ = os.Unsetenv("HOST_METERING_HOST_CERT_KEY_PATH")
 	_ = os.Unsetenv("HOST_METERING_COLLECT_INTERVAL_SEC")
+	_ = os.Unsetenv("HOST_METERING_SEND_HOSTNAME")
 	_ = os.Unsetenv("HOST_METERING_LABEL_REFRESH_INTERVAL_SEC")
 	_ = os.Unsetenv("HOST_METERING_WRITE_RETRY_ATTEMPTS")
 	_ = os.Unsetenv("HOST_METERING_WRITE_RETRY_MIN_INT_SEC")

--- a/contrib/man/host-metering.1
+++ b/contrib/man/host-metering.1
@@ -62,6 +62,9 @@ Interval between collecting host metrics in seconds.
 \fBHOST_METERING_LABEL_REFRESH_INTERVAL_SEC\fR
 Interval between refreshing host labels in seconds.
 
+\fBHOST_METERING_SEND_HOSTNAME\fR
+Send hostname to remote server. By default \fByes\fR set to \fBno\fR to disable.
+
 \fBHOST_METERING_WRITE_RETRY_ATTEMPTS\fR
 Number of write attempts to remote server.
 

--- a/contrib/man/host-metering.conf.5
+++ b/contrib/man/host-metering.conf.5
@@ -51,6 +51,12 @@ Interval between refreshing host labels in seconds.
 .RE
 
 .PP
+send_hostname (string)
+.RS 4
+Send hostname to remote server. By default \fByes\fR set to \fBno\fR to disable.
+.RE
+
+.PP
 write_retry_attempts (integer)
 .RS 4
 Number of write attempts to remote server.


### PR DESCRIPTION
**feat: add send_hostname configuration option**

And its `HOST_METERING_SEND_HOSTNAME` env var counterpart.

Possible values and meaning:
- yes: display_name label should be sent
- no: display_name label should not be sent
- undefined or unexpected value: display_name label should be sent

**feat: filter out labels based on configuration**

Filter out labels that the Prometheus notifier sends based on
configuration. Atm the only label supported by this is "display_name".

https://issues.redhat.com/browse/HMS-3264



