### PR TITLE
build: fix Fedora rpm build

### DIFF
--- a/contrib/rpm/host-metering.spec.in
+++ b/contrib/rpm/host-metering.spec.in
@@ -36,6 +36,11 @@ BuildRequires: go-toolset-1.19
 BuildRequires: golang >= 1.19
 BuildRequires: systemd-rpm-macros
 %endif
+
+%if 0%{?rhel} > 8 || 0%{?fedora}
+BuildRequires: go-rpm-macros
+%endif
+
 BuildRequires: git
 BuildRequires: policycoreutils
 BuildRequires: selinux-policy


### PR DESCRIPTION
It started to fail in COPR. It's possible that go-rpm-macros is not automatically present - Fedora packaging guidelines mentions that they should be present.

Thus adding them as BuildRequires.