### PR TITLE
[HMS-3358] feat: enable host-metering.service on rpm installation

### DIFF
--- a/contrib/rpm/host-metering.spec.in
+++ b/contrib/rpm/host-metering.spec.in
@@ -78,6 +78,8 @@ install -m 0755 -vd                     %{buildroot}%{_bindir}
 install -m 0755 -vp $(pwd)/bin/*        %{buildroot}%{_bindir}/
 install -m 0755 -vd                     %{buildroot}%{_unitdir}
 install -m 644 contrib/systemd/host-metering.service %{buildroot}%{_unitdir}/%{name}.service
+install -m 0755 -vd                     %{buildroot}%{_presetdir}
+install -m 644 contrib/systemd/80-host-metering.preset %{buildroot}%{_presetdir}/80-%{name}.preset
 install -m 0755 -vd                     %{buildroot}%{_mandir}/man1
 install -m 644 contrib/man/host-metering.1 %{buildroot}%{_mandir}/man1/host-metering.1
 install -m 0755 -vd                     %{buildroot}%{_mandir}/man5
@@ -91,7 +93,7 @@ install -D -p -m 644 contrib/selinux/%{modulename}.if %{buildroot}%{_datadir}/se
 %endif
 
 %post
-/bin/systemctl --system daemon-reload 2>&1 || :
+%systemd_post %{name}.service
 
 %post selinux
 %selinux_modules_install -s %{selinuxtype} %{_datadir}/selinux/packages/%{selinuxtype}/%{modulename}.pp
@@ -102,20 +104,11 @@ if [ "$1" -le "1" ]; then # First install
    %systemd_postun_with_restart %{modulename}.service
 fi
 
-%posttrans
-# restart on upgrade if was enabled
-/bin/systemctl is-enabled host-metering.service >/dev/null 2>&1
-if [  $? -eq 0 ]; then
-    /bin/systemctl restart host-metering.service >/dev/null || :
-fi
-
-
 %preun
-# stop and disable on uninstallation
-if [ $1 -eq 0 ]; then
-    /bin/systemctl --quiet stop host-metering.service || :
-    /bin/systemctl --quiet disable host-metering.service || :
-fi
+%systemd_preun %{name}.service
+
+%postun
+%systemd_postun_with_restart %{name}.service
 
 %postun selinux
 if [ $1 -eq 0 ]; then
@@ -129,6 +122,7 @@ fi
 %attr(644,root,root) %{_unitdir}/%{name}.service
 %{_mandir}/man1/host-metering.1*
 %{_mandir}/man5/host-metering.conf.5*
+%{_presetdir}/*.preset
 
 %files selinux
 %{_datadir}/selinux/packages/%{selinuxtype}/%{modulename}.pp

--- a/contrib/systemd/80-host-metering.preset
+++ b/contrib/systemd/80-host-metering.preset
@@ -1,0 +1,1 @@
+enable host-metering.service


### PR DESCRIPTION
**feat: enable host-metering.service on rpm installation**

Use systemd preset for enabling host-metering.

Refactor systemd calls to macros as recommended by packaging policy.

**feat: start host-metering service on rpm installation**

The host-metering.service is started at the end of transaction if the
service is enabled. It is enabled by preset, so it is possible to
disable it also by other preset with higher priority.

It's in selinux poststrans as it was otherwise failing with permissions
issues.

Overall this is a hack and e.g. might be against Fedora packaging
policy.

https://issues.redhat.com/browse/HMS-3358