### PR TITLE
docs: fix typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,7 +132,7 @@ It:
 ### Testing release
 
 It is a bit tricky to test the release process locally. It might be easier
-to do the changes, pushed them to your fork's main branch on GitHub and execute
+to do the changes, push them to your fork's main branch on GitHub and execute
 the release there.
 
 In local machine testing, make sure that the git repo has only your fork as

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ $ make test-daemon
 ```
 
 It will run `host-metering` with:
-* mocked `subscriptin-manager`
+* mocked `subscription-manager`
 * test configuration file that is lowering intervals and using the following:
 * test certificate
 * custom path for metrics WAL

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -54,7 +54,7 @@ func (d *Daemon) Run() error {
 	signal.Notify(d.stopCh, syscall.SIGINT, syscall.SIGTERM)
 	shutdownCh := make(chan int)
 
-	// Wait for SIGHUP to reload host ifo
+	// Wait for SIGHUP to reload host info
 	reloadCh := make(chan os.Signal, 1)
 	signal.Notify(reloadCh, syscall.SIGHUP)
 


### PR DESCRIPTION
Fix typos in README.md, CONTRIBUTING.md, and daemon.go comment to improve readability.