### PR TITLE
docs: add missing module to commitlint installation instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,7 +103,7 @@ Similarly, a Deprecation section should start with "DEPRECATED: " followed by a 
 ### Check commit message locally:
 
 ```
-$ npm install commitlint@latest @commitlint/config-angular@latest
+$ npm install commitlint@latest @commitlint/config-conventional@latest
 $ npx commitlint --from HEAD~1
 ```
 


### PR DESCRIPTION
Add missing config-conventional module to commitlint installation instructions in CONTRIBUTING.md to fix missing module error.