### PR TITLE
build: adapt local test daemons for ubi 7/8/9 dev tests

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,3 +1,5 @@
-FROM registry.access.redhat.com/ubi7/go-toolset:1.19
+ARG UBI_VERSION
+
+FROM registry.access.redhat.com/ubi${UBI_VERSION}/go-toolset:1.19
 
 ENV IS_IN_CONTAINER=true

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ NEXT_VERSION ?=
 SHORT_COMMIT ?= $(shell git rev-parse --short=8 HEAD)
 AUTORELEASE ?= "git$(shell date "+%Y%m%d%H%M")G$(SHORT_COMMIT)"
 
+UBI_VERSION ?= 7
+
 DISTDIR ?= $(CURDIR)/dist
 RPMTOPDIR := $(DISTDIR)/rpmbuild
 
@@ -70,7 +72,7 @@ endif
 
 .PHONY: test-daemon
 test-daemon: cert build container-env-setup $(CONTAINER_TARGET)
-	@echo "Running the $(PROJECT) in deamon mode..."
+	@echo "Running $(PROJECT) in daemon mode..."
 
 	PATH=$(MOCKS_DIR):$(PATH) \
 	HOST_METERING_WRITE_URL=$(PROMETHEUS_ADDRESS) \
@@ -86,8 +88,8 @@ mocks/consumer/cert.pem mocks/consumer/key.pem:
 
 .PHONY: podman-containers
 podman-containers:
-	podman-compose -f .devcontainer/docker-compose.yml build
-
+	podman build --no-cache -t devcontainer_host-metering --build-arg UBI_VERSION=$(UBI_VERSION) -f .devcontainer/Dockerfile .
+	
 .PHONY: prometheus
 prometheus: podman-containers
 	@echo "See the dashboard at: ${DASHBOARD_URL}"

--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ It will run `host-metering` with:
 * custom path for metrics WAL
 * Prometheus server started in a podman container
 
+Note: You may specifiy the UBI version you wish to test with the optional `UBI_VERSION` argument. If not specified, it will default to 7:
+
+```
+$ make test-daemon UBI_VERSION=<version_number>
+```
+
 Query Prometheus, e.g., via command:
 
 ```


### PR DESCRIPTION
Adjust Dockerfile and Makefile to allow for easier testing of different ubi environments via optional make test-daemon argument for specifying the desired ubi version.

https://issues.redhat.com/browse/CLOUDX-807

Note: 
There appears to be a bug with podman-compose (1.0.6) where it returns exit code 0 even when there is an error pulling the image:
https://github.com/containers/podman-compose/issues/586
https://github.com/containers/podman-compose/issues/501

This was causing the build process to continue using the previous ubi environment. To prevent this, I replaced the relevant podman-compose command with the equivalent podman build command, but I'm unsure if this is the ideal solution!