### PR TITLE
refactor: replace go-log with logrus

### DIFF
--- a/.devcontainer/host-metering.conf
+++ b/.devcontainer/host-metering.conf
@@ -18,4 +18,3 @@ write_retry_max_int_sec=2
 metrics_wal_path=./mocks/cpumetrics
 metrics_max_age_sec=30
 log_level=DEBUG
-log_prefix=%S

--- a/config/config.go
+++ b/config/config.go
@@ -31,7 +31,6 @@ const (
 	DefaultMetricsWALPath       = "/var/run/host-metering/metrics"
 	DefaultLogLevel             = "INFO"
 	DefaultLogPath              = "" //Default to stderr, will be logged in journal.
-	DefaultLogPrefix            = ""
 )
 
 type Config struct {
@@ -50,7 +49,6 @@ type Config struct {
 	MetricsWALPath       string
 	LogLevel             string // one of "ERROR", "WARN", "INFO", "DEBUG", "TRACE"
 	LogPath              string
-	LogPrefix            string
 }
 
 func NewConfig() *Config {
@@ -70,7 +68,6 @@ func NewConfig() *Config {
 		MetricsWALPath:       DefaultMetricsWALPath,
 		LogLevel:             DefaultLogLevel,
 		LogPath:              DefaultLogPath,
-		LogPrefix:            DefaultLogPrefix,
 	}
 }
 
@@ -93,7 +90,6 @@ func (c *Config) String() string {
 			fmt.Sprintf("|  MetricsWALPath: %s", c.MetricsWALPath),
 			fmt.Sprintf("|  LogLevel: %s", c.LogLevel),
 			fmt.Sprintf("|  LogPath: %s", c.LogPath),
-			fmt.Sprintf("|  LogPrefix: %s", c.LogPrefix),
 		}, "\n")
 }
 
@@ -153,9 +149,6 @@ func (c *Config) UpdateFromEnvVars() error {
 	}
 	if v := os.Getenv("HOST_METERING_LOG_PATH"); v != "" {
 		c.LogPath = v
-	}
-	if v := os.Getenv("HOST_METERING_LOG_PREFIX"); v != "" {
-		c.LogPrefix = v
 	}
 	return multiError.ErrorOrNil()
 }
@@ -273,9 +266,6 @@ func (c *Config) UpdateFromConfigFile(path string) error {
 	}
 	if v, ok := config[section]["log_path"]; ok {
 		c.LogPath = v
-	}
-	if v, ok := config[section]["log_prefix"]; ok {
-		c.LogPrefix = v
 	}
 
 	return multiError.ErrorOrNil()

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -26,8 +26,7 @@ func TestDefaultConfig(t *testing.T) {
 		"|  MetricsMaxAgeSec: 5400\n" +
 		"|  MetricsWALPath: /var/run/host-metering/metrics\n" +
 		"|  LogLevel: INFO\n" +
-		"|  LogPath: \n" +
-		"|  LogPrefix: \n"
+		"|  LogPath: \n"
 
 	// Create the default configuration.
 	c := NewConfig()
@@ -74,8 +73,7 @@ func TestConfigFile(t *testing.T) {
 		"|  MetricsMaxAgeSec: 700\n" +
 		"|  MetricsWALPath: /tmp/metrics\n" +
 		"|  LogLevel: ERROR\n" +
-		"|  LogPath: /tmp/log\n" +
-		"|  LogPrefix: %d%t\n"
+		"|  LogPath: /tmp/log\n"
 
 	// Update the configuration from a valid config file.
 	fileContent := "[host-metering]\n" +
@@ -95,9 +93,7 @@ func TestConfigFile(t *testing.T) {
 		"metrics_max_age_sec = 700\n" +
 		"metrics_wal_path = /tmp/metrics\n" +
 		"log_level = ERROR\n" +
-		"log_path = /tmp/log\n" +
-		"log_prefix = %d%t\n"
-
+		"log_path = /tmp/log\n"
 	c := NewConfig()
 
 	createConfigFile(t, path, fileContent)
@@ -155,8 +151,7 @@ func TestEnvVariables(t *testing.T) {
 		"|  MetricsMaxAgeSec: 700\n" +
 		"|  MetricsWALPath: /tmp/metrics\n" +
 		"|  LogLevel: ERROR\n" +
-		"|  LogPath: /tmp/log\n" +
-		"|  LogPrefix: %d\n"
+		"|  LogPath: /tmp/log\n"
 
 	// Set valid environment variables.
 	t.Setenv("HOST_METERING_WRITE_URL", "http://test/url")
@@ -174,7 +169,6 @@ func TestEnvVariables(t *testing.T) {
 	t.Setenv("HOST_METERING_METRICS_WAL_PATH", "/tmp/metrics")
 	t.Setenv("HOST_METERING_LOG_LEVEL", "ERROR")
 	t.Setenv("HOST_METERING_LOG_PATH", "/tmp/log")
-	t.Setenv("HOST_METERING_LOG_PREFIX", "%d")
 
 	// Environment variables are set. Change the defaults.
 	c := NewConfig()
@@ -229,7 +223,6 @@ func clearEnvironment() {
 	_ = os.Unsetenv("HOST_METERING_METRICS_WAL_PATH")
 	_ = os.Unsetenv("HOST_METERING_LOG_LEVEL")
 	_ = os.Unsetenv("HOST_METERING_LOG_PATH")
-	_ = os.Unsetenv("HOST_METERING_LOG_PREFIX")
 }
 
 func checkError(t *testing.T, err error, message string) {

--- a/contrib/man/host-metering.1
+++ b/contrib/man/host-metering.1
@@ -89,49 +89,6 @@ Log level. Possible values are: DEBUG, INFO, WARN, ERROR, TRACE.
 \fBHOST_METERING_LOG_PATH\fR
 Path to log file. Default is empty - stderr.
 
-\fBHOST_METERING_LOG_PREFIX\fR
-Prefix of log messages. Default is empty. Format: "[PREFIX][FLAG]*"
-
-.RS 4
-
-\fBPREFIX:\fR string until first occurance of %
-
-\fBFLAGS:\fR
-.RS 4
-.TP
-.B %d
-Date
-
-.TP
-.B %t
-Time
-
-.TP
-.B %m
-Microseconds
-
-.TP
-.B %l
-Long file name
-
-.TP
-.B %s
-Short file name
-
-.TP
-.B %z
-Use UTC
-
-.TP
-.B %p
-Move the "PREFIX" from the beginning of the line to before the message
-
-.TP
-.B %S
-Datetime (same as "%d %t")
-.RE
-.RE
-
 .SH "FILES"
 .PP
 \fI/etc/host-metering.conf\fR

--- a/contrib/man/host-metering.conf.5
+++ b/contrib/man/host-metering.conf.5
@@ -104,49 +104,6 @@ log_path (string)
 Path to log file. Default is empty - stderr.
 .RE
 
-.PP
-log_prefix (string)
-.RS 4
-Prefix of log messages. Default is empty. Format: "[PREFIX][FLAG]*"
-
-\fBPREFIX:\fR string until first occurance of %
-
-\fBFLAGS:\fR
-.RS 4
-.TP
-.B %d
-Date
-
-.TP
-.B %t
-Time
-
-.TP
-.B %m
-Microseconds
-
-.TP
-.B %l
-Long file name
-
-.TP
-.B %s
-Short file name
-
-.TP
-.B %z
-Use UTC
-
-.TP
-.B %p
-Move the "PREFIX" from the beginning of the line to before the message
-
-.TP
-.B %S
-Datetime (same as "%d %t")
-.RE
-.RE
-
 .SH "EXAMPLES"
 .PP
 1\&. The following example shows how to switch the logging to DEBUG level\&.

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,12 @@ module github.com/RedHatInsights/host-metering
 go 1.19
 
 require (
-	git.sr.ht/~spc/go-log v0.0.0-20230531172318-1397be06f5f4 // direct
 	github.com/fsnotify/fsnotify v1.6.0 // direct
 	github.com/gogo/protobuf v1.3.2 // direct
 	github.com/golang/snappy v0.0.4 // direct
 	github.com/prometheus/procfs v0.11.0 // direct
 	github.com/prometheus/prometheus v0.45.0 // direct
+	github.com/sirupsen/logrus v1.9.3 // direct
 	github.com/tidwall/wal v1.1.7 // direct
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
-git.sr.ht/~spc/go-log v0.0.0-20230531172318-1397be06f5f4 h1:Z49DWDPi2qdWYkpgq+WEv1hQIGB2fVmva361Zs7/Qzg=
-git.sr.ht/~spc/go-log v0.0.0-20230531172318-1397be06f5f4/go.mod h1:IKiYUc0lWbZO4uSV0kWNzJSFnABNdrybpPWo46CGgFM=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
@@ -9,10 +10,17 @@ github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEW
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/procfs v0.11.0 h1:5EAgkfkMl659uZPbe9AS2N68a7Cc1TJbPEuGzFuRbyk=
 github.com/prometheus/procfs v0.11.0/go.mod h1:nwNm2aOCAYw8uTR/9bWRREkZFxAUcWzPHWJq+XBB/FM=
 github.com/prometheus/prometheus v0.45.0 h1:O/uG+Nw4kNxx/jDPxmjsSDd+9Ohql6E7ZSY1x5x/0KI=
 github.com/prometheus/prometheus v0.45.0/go.mod h1:jC5hyO8ItJBnDWGecbEucMyXjzxGv9cxsxsjS9u5s1w=
+github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
+github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/tidwall/gjson v1.10.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/gjson v1.16.0 h1:SyXa+dsSPpUlcwEDuKuEBJEz5vzTvOea+9rjyYodQFg=
 github.com/tidwall/gjson v1.16.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
@@ -43,6 +51,7 @@ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.8.0 h1:EBmGv8NaZBZTWvrbjNoL6HVt+IVy3QDQpJs7VRIw3tU=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -56,3 +65,6 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -4,8 +4,6 @@ import (
 	"os"
 	"strings"
 	"testing"
-
-	std_log "log"
 )
 
 // Test that logger global functions won't crash even if the logger is not initialized.
@@ -37,18 +35,11 @@ func TestLoggerGlobalFunctions(t *testing.T) {
 	Debugf("Debugf Test %s", "test")
 	clearLogger()
 	Debugln("Debugln Test")
-
-	clearLogger()
-	Trace("Trace Test")
-	clearLogger()
-	Tracef("Tracef Tracef %s", "test")
-	clearLogger()
-	Traceln("Traceln Traceln Test")
 }
 
 // Test initialization of logger with only log level
 func TestInitLogger(t *testing.T) {
-	InitLogger("", DebugLevel, defaultLogPrefix, defaultLogFormat)
+	InitLogger("", DebugLevel.String())
 	if log == nil {
 		t.Fatalf("logger is not initialized")
 	}
@@ -60,7 +51,7 @@ func TestInitLogger(t *testing.T) {
 func TestInitLoggerFile(t *testing.T) {
 	dir := t.TempDir()
 	path := dir + "/test.log"
-	InitLogger(path, DebugLevel, defaultLogPrefix, defaultLogFormat)
+	InitLogger(path, DebugLevel.String())
 	if log == nil {
 		t.Fatalf("logger is not initialized")
 	}
@@ -177,23 +168,8 @@ func TestOverridenLogger(t *testing.T) {
 		t.Fatalf("Debugln message is not logged")
 	}
 
-	Trace("Trace Test")
-	if !logger.IsLastEntry(TraceLevel, "Trace Test", "Trace") {
-		t.Fatalf("Trace message is not logged")
-	}
-
-	Tracef("Tracef Tracef %s", "test")
-	if !logger.IsLastEntry(TraceLevel, "Tracef Tracef test", "Tracef") {
-		t.Fatalf("Tracef message is not logged")
-	}
-
-	Traceln("Traceln Traceln Test")
-	if !logger.IsLastEntry(TraceLevel, "Traceln Traceln Test", "Traceln") {
-		t.Fatalf("Traceln message is not logged")
-	}
-
 	entries := logger.GetEntries()
-	if len(entries) != 15 {
+	if len(entries) != 12 {
 		t.Fatalf("unexpected number of log entries: %d", len(entries))
 	}
 
@@ -203,42 +179,6 @@ func TestOverridenLogger(t *testing.T) {
 	if len(entries) != 0 {
 		t.Fatalf("unexpected number of log entries after clear: %d", len(entries))
 	}
-}
-
-type LogPrefixTestCase struct {
-	prefix         string
-	expectedPrefix string
-	expectedFlag   int
-}
-
-func TestParseLogPrefix(t *testing.T) {
-	testCases := []LogPrefixTestCase{
-		{"", "", 0},
-		{"test", "test", 0},
-		{"test:", "test:", 0},
-		{"test: ", "test: ", 0},
-		{"test: %d", "test: ", std_log.Ldate},
-		{"test: %d %t", "test: ", std_log.Ldate | std_log.Ltime},
-		{"test: %d %t %m", "test: ", std_log.Ldate | std_log.Ltime | std_log.Lmicroseconds},
-		{"test: %S %l", "test: ", std_log.LstdFlags | std_log.Llongfile},
-		{"test: %S %s", "test: ", std_log.LstdFlags | std_log.Lshortfile},
-		{"test: %S %z", "test: ", std_log.LstdFlags | std_log.LUTC},
-		{"test%S %p", "test", std_log.LstdFlags | std_log.Lmsgprefix},
-		{"test: %S", "test: ", std_log.LstdFlags},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.prefix, func(t *testing.T) {
-			prefix, flag := ParseLogPrefix(tc.prefix)
-			if prefix != tc.expectedPrefix {
-				t.Fatalf("expected prefix: %s got: %s", tc.prefix, prefix)
-			}
-			if flag != tc.expectedFlag {
-				t.Fatalf("expected flag: %d got: %d", tc.expectedFlag, flag)
-			}
-		})
-	}
-
 }
 
 // Helper functions

--- a/main.go
+++ b/main.go
@@ -47,8 +47,7 @@ func main() {
 		}
 
 		// initialize the logger according to the given configuration
-		logPrefix, logFlag := logger.ParseLogPrefix(cfg.LogPrefix)
-		err = logger.InitLogger(cfg.LogPath, cfg.LogLevel, logPrefix, logFlag)
+		err = logger.InitLogger(cfg.LogPath, cfg.LogLevel)
 
 		if err != nil {
 			logger.Debugf("Error initializing logger: %s\n", err.Error())


### PR DESCRIPTION
Replace deprecated go-log with Logrus and replace
the ParseLogPrefix function with a custom formatter to 
maintain log formatting in a manner compatible with Logrus

https://issues.redhat.com/browse/CLOUDX-864