### PR TITLE
ci: update github actions to use node.js 20

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -7,11 +7,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "lts/*"
       - name: Print versions

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: '1.19'
 
@@ -27,14 +27,14 @@ jobs:
       run: make test
 
     - name: Upload Go coverage results - HTML
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: go-coverage
+        name: go-coverage-html
         path: coverage.html
 
     - name: Upload Go coverage results - txt
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: go-coverage
+        name: go-coverage-txt
         path: coverage.txt
 


### PR DESCRIPTION
Update deprecated Node.js 16 actions in commitlint.yml and go.yml to use Node.js 20.

https://issues.redhat.com/browse/CLOUDX-889

Updates the following actions: 
checkout@v3 --> [checkout@v4](https://github.com/actions/checkout/releases/tag/v4.0.0)
setup-node@v3 --> [setup-node@v4](https://github.com/actions/setup-node/releases/tag/v4.0.0)
setup-go@v4 --> [setup-go@v5](https://github.com/actions/setup-go/releases/tag/v5.0.0)
upload-artifact@v3 --> [upload-artifact@v4](https://github.com/actions/upload-artifact/releases/tag/v4.0.0)

NOTE: 
As of upload-artifact@v4, it's no longer possible to upload multiple same-named artifacts (see the second breaking change [here](https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes), so I split the "go-coverage" artifact in go.yml into two separately named artifacts. Any feedback on this approach is appreciated!