### PR TITLE
docs: fix typos and remove refs to redundant code

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ It will run `host-metering` with:
 * custom path for metrics WAL
 * Prometheus server started in a podman container
 
-Note: You may specifiy the UBI version you wish to test with the optional `UBI_VERSION` argument. If not specified, it will default to 7:
+Note: You may specify the UBI version you wish to test with the optional `UBI_VERSION` argument. If not specified, it will default to 7:
 
 ```
 $ make test-daemon UBI_VERSION=<version_number>

--- a/config/config.go
+++ b/config/config.go
@@ -48,7 +48,7 @@ type Config struct {
 	WriteTimeout         time.Duration
 	MetricsMaxAge        time.Duration
 	MetricsWALPath       string
-	LogLevel             string // one of "ERROR", "WARN", "INFO", "DEBUG", "TRACE"
+	LogLevel             string // one of "ERROR", "WARN", "INFO", "DEBUG"
 	LogPath              string
 	InstanceID           string
 }

--- a/contrib/man/host-metering.1
+++ b/contrib/man/host-metering.1
@@ -84,7 +84,7 @@ Maximum age of collected metrics in seconds. After the time, the metrics are dro
 Path to directory where write ahead log files are stored.
 
 \fBHOST_METERING_LOG_LEVEL\fR
-Log level. Possible values are: DEBUG, INFO, WARN, ERROR, TRACE.
+Log level. Possible values are: DEBUG, INFO, WARN, ERROR.
 
 \fBHOST_METERING_LOG_PATH\fR
 Path to log file. Default is empty - stderr.

--- a/contrib/man/host-metering.conf.5
+++ b/contrib/man/host-metering.conf.5
@@ -95,7 +95,7 @@ Path to directory where write ahead log files are stored.
 .PP
 log_level (string)
 .RS 4
-Log level. Possible values are: DEBUG, INFO, WARN, ERROR, TRACE.
+Log level. Possible values are: DEBUG, INFO, WARN, ERROR.
 .RE
 
 .PP

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -53,9 +53,10 @@ func TestRunWithCollect(t *testing.T) {
 	daemon.config.CollectInterval = 20 * time.Millisecond
 	daemon.config.WriteInterval = 30 * time.Millisecond
 
-	// Test that deamon does initial notification on start before
+	// Test that daemon does initial notification on start
 	go daemon.Run()
 	checkRunning(t, daemon)
+
 	// Check initial notification (before fully started)
 	notifier.WaitForCall(t, 10*time.Millisecond)
 	if len(notifier.calledWith.samples) != 1 {
@@ -171,7 +172,7 @@ func TestNotify(t *testing.T) {
 		t.Fatalf("expected hostinfo to be passed to notifier")
 	}
 
-	// Test that log is trunctated after notifying
+	// Test that log is truncated after notifying
 	checkEmptyMetricsLog(t, metricsLog)
 
 	// Test that notifier is not called when there are no samples
@@ -304,7 +305,7 @@ func TestRunWithoutLabelRefresh(t *testing.T) {
 
 // Helper functions
 
-// Wait and check if deamon run was initiated
+// Wait and check if daemon run was initiated
 func checkRunning(t *testing.T, daemon *Daemon) {
 	timeout := time.NewTimer(10 * time.Millisecond)
 	defer timeout.Stop()
@@ -321,7 +322,7 @@ func checkRunning(t *testing.T, daemon *Daemon) {
 	}
 }
 
-// Wait and check if deamon is not started
+// Wait and check if daemon is not started
 func waitForStopped(t *testing.T, daemon *Daemon) {
 	t.Helper()
 	timeout := time.NewTimer(10 * time.Millisecond)
@@ -339,7 +340,7 @@ func waitForStopped(t *testing.T, daemon *Daemon) {
 	}
 }
 
-// Wait and check if deamon is started
+// Wait and check if daemon is started
 func waitForStarted(t *testing.T, daemon *Daemon) {
 	t.Helper()
 	timeout := time.NewTimer(100 * time.Millisecond)

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -43,7 +43,7 @@ func TestInitLogger(t *testing.T) {
 	if log == nil {
 		t.Fatalf("logger is not initialized")
 	}
-	// Test some usuage
+	// Test some usage
 	log.Debug("Debug Test")
 }
 
@@ -56,7 +56,7 @@ func TestInitLoggerFile(t *testing.T) {
 		t.Fatalf("logger is not initialized")
 	}
 	testMsg := "Test message"
-	// Test some usuage
+	// Test some usage
 	log.Debug(testMsg)
 
 	// Check that the file is created
@@ -77,7 +77,7 @@ func TestInitLoggerFile(t *testing.T) {
 	}
 }
 
-// Test that logger can be raplaced by other implementation of Logger interface.
+// Test that logger can be replaced by other implementation of Logger interface.
 func TestOverrideLogger(t *testing.T) {
 	logger := NewTestLogger()
 	OverrideLogger(logger)
@@ -91,7 +91,7 @@ func TestOverrideLogger(t *testing.T) {
 	}
 }
 
-// Test that global logger functions will use the overriden logger.
+// Test that global logger functions will use the overridden logger.
 func TestOverridenLogger(t *testing.T) {
 	logger := NewTestLogger()
 	OverrideLogger(logger)


### PR DESCRIPTION
Fix typos and remove references to no longer existing code in comments to improve readability