### PR TITLE
Function and var typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ It will run `host-metering` with:
 * custom path for metrics WAL
 * Prometheus server started in a podman container
 
-Note: You may specifiy the UBI version you wish to test with the optional `UBI_VERSION` argument. If not specified, it will default to 7:
+Note: You may specify the UBI version you wish to test with the optional `UBI_VERSION` argument. If not specified, it will default to 7:
 
 ```
 $ make test-daemon UBI_VERSION=<version_number>

--- a/config/config.go
+++ b/config/config.go
@@ -48,7 +48,7 @@ type Config struct {
 	WriteTimeout         time.Duration
 	MetricsMaxAge        time.Duration
 	MetricsWALPath       string
-	LogLevel             string // one of "ERROR", "WARN", "INFO", "DEBUG", "TRACE"
+	LogLevel             string // one of "ERROR", "WARN", "INFO", "DEBUG"
 	LogPath              string
 	InstanceID           string
 }

--- a/contrib/man/host-metering.1
+++ b/contrib/man/host-metering.1
@@ -42,7 +42,7 @@ A single asterisk (*) indicates that no proxying should be done.
 A best effort is made to parse the string and errors are
 ignored.
 
-More details can be found on the offical go http documentation: https://pkg.go.dev/net/http#ProxyFromEnvironment
+More details can be found on the official go http documentation: https://pkg.go.dev/net/http#ProxyFromEnvironment
 
 \fBHOST_METERING_WRITE_URL\fR
 Remote server endpoint.
@@ -84,7 +84,7 @@ Maximum age of collected metrics in seconds. After the time, the metrics are dro
 Path to directory where write ahead log files are stored.
 
 \fBHOST_METERING_LOG_LEVEL\fR
-Log level. Possible values are: DEBUG, INFO, WARN, ERROR, TRACE.
+Log level. Possible values are: DEBUG, INFO, WARN, ERROR.
 
 \fBHOST_METERING_LOG_PATH\fR
 Path to log file. Default is empty - stderr.

--- a/contrib/man/host-metering.conf.5
+++ b/contrib/man/host-metering.conf.5
@@ -95,7 +95,7 @@ Path to directory where write ahead log files are stored.
 .PP
 log_level (string)
 .RS 4
-Log level. Possible values are: DEBUG, INFO, WARN, ERROR, TRACE.
+Log level. Possible values are: DEBUG, INFO, WARN, ERROR.
 .RE
 
 .PP

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -53,9 +53,10 @@ func TestRunWithCollect(t *testing.T) {
 	daemon.config.CollectInterval = 20 * time.Millisecond
 	daemon.config.WriteInterval = 30 * time.Millisecond
 
-	// Test that deamon does initial notification on start before
+	// Test that daemon does initial notification on start
 	go daemon.Run()
 	checkRunning(t, daemon)
+
 	// Check initial notification (before fully started)
 	notifier.WaitForCall(t, 10*time.Millisecond)
 	if len(notifier.calledWith.samples) != 1 {
@@ -171,7 +172,7 @@ func TestNotify(t *testing.T) {
 		t.Fatalf("expected hostinfo to be passed to notifier")
 	}
 
-	// Test that log is trunctated after notifying
+	// Test that log is truncated after notifying
 	checkEmptyMetricsLog(t, metricsLog)
 
 	// Test that notifier is not called when there are no samples
@@ -304,7 +305,7 @@ func TestRunWithoutLabelRefresh(t *testing.T) {
 
 // Helper functions
 
-// Wait and check if deamon run was initiated
+// Wait and check if daemon run was initiated
 func checkRunning(t *testing.T, daemon *Daemon) {
 	timeout := time.NewTimer(10 * time.Millisecond)
 	defer timeout.Stop()
@@ -321,7 +322,7 @@ func checkRunning(t *testing.T, daemon *Daemon) {
 	}
 }
 
-// Wait and check if deamon is not started
+// Wait and check if daemon is not started
 func waitForStopped(t *testing.T, daemon *Daemon) {
 	t.Helper()
 	timeout := time.NewTimer(10 * time.Millisecond)
@@ -339,7 +340,7 @@ func waitForStopped(t *testing.T, daemon *Daemon) {
 	}
 }
 
-// Wait and check if deamon is started
+// Wait and check if daemon is started
 func waitForStarted(t *testing.T, daemon *Daemon) {
 	t.Helper()
 	timeout := time.NewTimer(100 * time.Millisecond)

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -43,7 +43,7 @@ func TestInitLogger(t *testing.T) {
 	if log == nil {
 		t.Fatalf("logger is not initialized")
 	}
-	// Test some usuage
+	// Test some usage
 	log.Debug("Debug Test")
 }
 
@@ -56,7 +56,7 @@ func TestInitLoggerFile(t *testing.T) {
 		t.Fatalf("logger is not initialized")
 	}
 	testMsg := "Test message"
-	// Test some usuage
+	// Test some usage
 	log.Debug(testMsg)
 
 	// Check that the file is created
@@ -77,7 +77,7 @@ func TestInitLoggerFile(t *testing.T) {
 	}
 }
 
-// Test that logger can be raplaced by other implementation of Logger interface.
+// Test that logger can be replaced by other implementation of Logger interface.
 func TestOverrideLogger(t *testing.T) {
 	logger := NewTestLogger()
 	OverrideLogger(logger)
@@ -91,7 +91,7 @@ func TestOverrideLogger(t *testing.T) {
 	}
 }
 
-// Test that global logger functions will use the overriden logger.
+// Test that global logger functions will use the overridden logger.
 func TestOverridenLogger(t *testing.T) {
 	logger := NewTestLogger()
 	OverrideLogger(logger)

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -85,14 +85,14 @@ func TestOverrideLogger(t *testing.T) {
 		t.Fatalf("logger is not overridden")
 	}
 
-	currrentLogger := getLogger()
-	if currrentLogger != logger {
+	currentLogger := getLogger()
+	if currentLogger != logger {
 		t.Fatalf("logger is not overridden")
 	}
 }
 
 // Test that global logger functions will use the overridden logger.
-func TestOverridenLogger(t *testing.T) {
+func TestOverriddenLogger(t *testing.T) {
 	logger := NewTestLogger()
 	OverrideLogger(logger)
 

--- a/notify/prometheus.go
+++ b/notify/prometheus.go
@@ -18,7 +18,7 @@ import (
 	"github.com/prometheus/prometheus/prompb"
 )
 
-// See https://prometheus.io/docs/concepts/remote_write_spec/ for specifiction of Prometheus remote write
+// See https://prometheus.io/docs/concepts/remote_write_spec/ for specification of Prometheus remote write
 
 // Should be used only for testing
 var tlsInsecureSkipVerify = false

--- a/notify/prometheus_test.go
+++ b/notify/prometheus_test.go
@@ -265,7 +265,7 @@ func TestNoRetriesOn4xx(t *testing.T) {
 	checkNonRecoverable(t, err)
 	checkCalled(t, called, 1)
 
-	// Test that retries are done on 429 but not on subsequest 404
+	// Test that retries are done on 429 but not on subsequent 404
 	err = prometheusRemoteWrite(client, cfg, request)
 	checkExpectedErrorContains(t, err, "http Error: 404")
 	checkNonRecoverable(t, err)

--- a/notify/prometheus_test.go
+++ b/notify/prometheus_test.go
@@ -91,7 +91,7 @@ func TestNotify(t *testing.T) {
 		}
 
 		// Test that request is in prometheus remote write format
-		checkPromethuesRemoteWriteHeaders(t, r)
+		checkPrometheusRemoteWriteHeaders(t, r)
 		checkRequestBody(t, r)
 		checkRequestUsesHostCert(t, r)
 
@@ -144,7 +144,7 @@ func TestNotifyNoCert(t *testing.T) {
 	err := n.Notify(samples, hostinfo)
 
 	if !strings.Contains(err.Error(), "no such file or directory") {
-		t.Fatal("Expected error on not finding certicate")
+		t.Fatal("Expected error on not finding certificate")
 	}
 }
 
@@ -321,7 +321,7 @@ func TestLabels(t *testing.T) {
 	createRequestAndCheckLabels(t, samples, hi)
 }
 
-func TestLableFiltering(t *testing.T) {
+func TestLabelFiltering(t *testing.T) {
 	// given
 	samples := createSamples()
 	hi := createHostInfo()
@@ -330,7 +330,7 @@ func TestLableFiltering(t *testing.T) {
 	writeRequest := hostInfo2WriteRequest(hi, samples, []string{"display_name", "socket_count"})
 
 	// then
-	checkLablesNotPresent(t, writeRequest.Timeseries[0].Labels, []string{"display_name", "socket_count"})
+	checkLabelsNotPresent(t, writeRequest.Timeseries[0].Labels, []string{"display_name", "socket_count"})
 }
 
 func TestFilterOutLabelsByName(t *testing.T) {
@@ -418,7 +418,7 @@ func createRequestAndCheckLabels(t *testing.T, samples []prompb.Sample, hostinfo
 // Helper checks
 
 // Check that the request has headers as expected in Prometheus remote write spec
-func checkPromethuesRemoteWriteHeaders(t *testing.T, r *http.Request) {
+func checkPrometheusRemoteWriteHeaders(t *testing.T, r *http.Request) {
 	if r.Header.Get("Content-Encoding") != "snappy" {
 		t.Errorf(
 			"Expected: `Content-Encoding: snappy` header, got: `%s`",
@@ -555,7 +555,7 @@ func checkLabelsPresence(t *testing.T, labels []prompb.Label, expected_names []s
 	}
 }
 
-func checkLablesNotPresent(t *testing.T, labels []prompb.Label, expected_missing []string) {
+func checkLabelsNotPresent(t *testing.T, labels []prompb.Label, expected_missing []string) {
 	t.Helper()
 	for _, name := range expected_missing {
 		for _, label := range labels {


### PR DESCRIPTION
This PR fixes some typos in docs and removes some outdated comments (e.g., comments which reference the no longer existing logger trace level). 
Submitted as two separate commits because some function names and local variables of functions also had typos.