### PR TITLE
build: add custom cfg for epel 7 mockbuilds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ rpm: rpm/srpm
 .PHONY: rpm/mock
 rpm/mock: rpm/srpm
 	mkdir -p $(DISTDIR)/mock7
-	mock -r epel-7-x86_64 \
+	mock -r contrib/rpm/epel-7-x86_64-custom.cfg \
 	     --resultdir=$(DISTDIR)/mock7/ \
 	     --rebuild $(RPMTOPDIR)/SRPMS/$(shell ls -1 $(RPMTOPDIR)/SRPMS)
 

--- a/contrib/rpm/epel-7-x86_64-custom.cfg
+++ b/contrib/rpm/epel-7-x86_64-custom.cfg
@@ -1,0 +1,104 @@
+
+# This list is taken from 'epel-7-x86_64' @buildsys-build group, minus the
+# 'epel-*' specific stuff, and has been modified to update the repository 
+# mirrors following the deprecation of mirrorlist.centos.org
+config_opts['chroot_setup_cmd'] = 'install bash bzip2 coreutils cpio diffutils findutils gawk gcc gcc-c++ grep gzip info make patch redhat-rpm-config rpm-build sed tar unzip util-linux which xz'
+
+config_opts['root'] = 'centos+epel-7-x86_64'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)
+config_opts['dist'] = 'el7' # only useful for --resultdir variable subst
+config_opts['releasever'] = '7'
+config_opts['bootstrap_image'] = 'quay.io/centos/centos:7'
+config_opts['package_manager'] = 'yum'
+config_opts['description'] = 'CentOS 7 + EPEL'
+
+config_opts['yum_install_command'] += "{% if target_arch in ['x86_64', 'ppc64le', 'aarch64'] %} --disablerepo=centos-sclo*{% endif %}"
+
+config_opts['yum.conf'] = """
+[main]
+keepcache=1
+debuglevel=2
+reposdir=/dev/null
+logfile=/var/log/yum.log
+retries=20
+obsoletes=1
+gpgcheck=0
+assumeyes=1
+syslog_ident=mock
+syslog_device=
+metadata_expire=0
+mdpolicy=group:primary
+best=1
+protected_packages=
+user_agent={{ user_agent }}
+
+{% set centos_7_gpg_keys = 'file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-7' %}
+{% if target_arch in ['ppc64le', 'ppc64'] %}
+{% set centos_7_gpg_keys = centos_7_gpg_keys + ',file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-SIG-AltArch-7-' + target_arch %}
+{% elif target_arch in ['aarch64'] %}
+{% set centos_7_gpg_keys = centos_7_gpg_keys + ',file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-7-aarch64' %}
+{% endif %}
+
+# repos
+[base]
+name=CentOS-$releasever - Base
+baseurl=https://vault.centos.org/7.9.2009/os/$basearch/
+failovermethod=priority
+gpgkey={{ centos_7_gpg_keys }}
+gpgcheck=1
+skip_if_unavailable=False
+
+[updates]
+name=CentOS-$releasever - Updates
+enabled=1
+baseurl=https://vault.centos.org/7.9.2009/updates/$basearch/
+failovermethod=priority
+gpgkey={{ centos_7_gpg_keys }}
+gpgcheck=1
+skip_if_unavailable=False
+
+[extras]
+name=CentOS-$releasever - Extras
+baseurl=https://vault.centos.org/7.9.2009/extras/$basearch/
+failovermethod=priority
+gpgkey={{ centos_7_gpg_keys }}
+gpgcheck=1
+skip_if_unavailable=False
+
+[fastrack]
+name=CentOS-$releasever - fasttrack
+baseurl=http://archive.kernel.org/centos-vault/7.9.2009/fastrack/$basearch/
+failovermethod=priority
+gpgkey={{ centos_7_gpg_keys }}
+gpgcheck=1
+skip_if_unavailable=False
+enabled=0
+
+[centosplus]
+name=CentOS-$releasever - Plus
+baseurl=https://archive.kernel.org/centos-vault/7.9.2009/centosplus/$basearch/
+gpgkey={{ centos_7_gpg_keys }}
+gpgcheck=1
+enabled=0
+
+{% if target_arch == 'x86_64' %}
+[centos-sclo-sclo]
+name=CentOS-$releasever - SCLo sclo
+baseurl=https://vault.centos.org/centos/7/sclo/$basearch/sclo/
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-SIG-SCLo
+gpgcheck=1
+skip_if_unavailable=False
+{% endif %}
+
+{% if target_arch in ['x86_64', 'ppc64le', 'aarch64'] %}
+[centos-sclo-rh]
+name=CentOS-$releasever - SCLo rh
+baseurl=https://vault.centos.org/7.9.2009/sclo/$basearch/rh/
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-SIG-SCLo
+gpgcheck=1
+skip_if_unavailable=False
+{% endif %}
+"""
+
+include('templates/epel-7.tpl')


### PR DESCRIPTION
Add a custom epel-7-x86_64.cfg config file to fix mock epel-7 builds failing due to deprecation of mirrorlist.centos.org