### PR TITLE
ci: replace epel-7-x86_64.cfg post centos7 eol

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -25,6 +25,7 @@ actions:
 
   post-upstream-clone:
     - "make rpm/spec"
+    - "cp contrib/rpm/epel-7-x86_64-custom.cfg /etc/mock/epel-7-x86_64.cfg"
 
 jobs:
 - job: copr_build


### PR DESCRIPTION
replace the epel-7-x86_64.cfg file in /etc/mock/ with a custom version containing missing repositories post CentOS 7 EOL to fix broken test pipelines.