### PR TITLE
fix: execute sub-man cli with c.utf-8 lang locale

### DIFF
--- a/hostinfo/subscription.go
+++ b/hostinfo/subscription.go
@@ -111,6 +111,9 @@ func GetBillingInfo(facts SubManValues) (BillingInfo, error) {
 
 func execSubManCommand(command ...string) (string, error) {
 	cmd := exec.Command("subscription-manager", command...)
+
+	// Set LANG to C.UTF-8 to force English output for predictable key lookups
+	cmd.Env = append(cmd.Environ(), "LANG=C.UTF-8")
 	logger.Debugf("Executing `subscription-manager %s`...\n", command)
 
 	var stdout, stderr bytes.Buffer


### PR DESCRIPTION
Alter the execSubManCommand function to execute subscription-manager commands with LANG set to C.UTF-8 to force English output regardless of system and service locale settings.
This is necessary to populate the SubManValues map with expected key names for subsequent key lookups, ensuring host information is correctly retrieved.

Solves [RHEL-49967](https://issues.redhat.com/browse/RHEL-49967)

Note: C.UTF-8 defaults to C on RHEL 7